### PR TITLE
ExportCommand

### DIFF
--- a/src/main/java/seedu/address/commons/events/model/AddressBookExportEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/AddressBookExportEvent.java
@@ -1,0 +1,23 @@
+package seedu.address.commons.events.model;
+
+import seedu.address.commons.events.BaseEvent;
+import seedu.address.model.ReadOnlyAddressBook;
+
+import java.nio.file.Path;
+
+/** Indicates the AddressBook in the model has triggered for export*/
+public class AddressBookExportEvent extends BaseEvent {
+
+    public final ReadOnlyAddressBook data;
+    public final Path path;
+
+    public AddressBookExportEvent(ReadOnlyAddressBook data, Path path) {
+        this.data = data;
+        this.path = path;
+    }
+
+    @Override
+    public String toString() {
+        return "number of persons " + data.getPersonList().size();
+    }
+}

--- a/src/main/java/seedu/address/commons/events/model/AddressBookExportEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/AddressBookExportEvent.java
@@ -1,9 +1,10 @@
 package seedu.address.commons.events.model;
 
+import java.nio.file.Path;
+
 import seedu.address.commons.events.BaseEvent;
 import seedu.address.model.ReadOnlyAddressBook;
 
-import java.nio.file.Path;
 
 /** Indicates the AddressBook in the model has triggered for export*/
 public class AddressBookExportEvent extends BaseEvent {

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -1,13 +1,13 @@
 package seedu.address.logic.commands;
 
-import seedu.address.model.Model;
-import seedu.address.logic.CommandHistory;
-import seedu.address.logic.commands.exceptions.CommandException;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
 
 import java.nio.file.Path;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
 
 /**
  * Export existing address book to user-defined path
@@ -29,6 +29,7 @@ public class ExportCommand extends Command {
         this.filepath = filePath;
     }
 
+    @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
 

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
 
 /**
-    Export existing address book to user-defined path
+ * Export existing address book to user-defined path
  */
 public class ExportCommand extends Command {
 
@@ -24,7 +24,7 @@ public class ExportCommand extends Command {
             + PREFIX_PATH + "backup";
 
     private Path filepath;
-    
+
     public ExportCommand(Path filePath) {
         this.filepath = filePath;
     }

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+
+import java.nio.file.Path;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
+
+/**
+    Export existing address book to user-defined path
+ */
+public class ExportCommand extends Command {
+
+    public static final String COMMAND_WORD = "export";
+    public static final String MESSAGE_EXPORT_SUCCESS = "Export process has been successful.";
+    public static final String MISSING_PATH = "";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Export the address book to specific filepath. "
+            + "Parameters: "
+            + PREFIX_PATH + "FilePath\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_PATH + "backup";
+
+    private Path filepath;
+    
+    public ExportCommand(Path filePath) {
+        this.filepath = filePath;
+    }
+
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        model.exportAddressBook(this.filepath);
+        return new CommandResult(MESSAGE_EXPORT_SUCCESS);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -49,48 +49,48 @@ public class AddressBookParser {
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
 
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+            case AddCommand.COMMAND_WORD:
+                return new AddCommandParser().parse(arguments);
 
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+            case EditCommand.COMMAND_WORD:
+                return new EditCommandParser().parse(arguments);
 
-        case SelectCommand.COMMAND_WORD:
-            return new SelectCommandParser().parse(arguments);
+            case SelectCommand.COMMAND_WORD:
+                return new SelectCommandParser().parse(arguments);
 
-        case DeleteCommand.COMMAND_WORD:
-        case DeleteCommand.COMMAND_ALIAS:
-            return new DeleteCommandParser().parse(arguments);
+            case DeleteCommand.COMMAND_WORD:
+            case DeleteCommand.COMMAND_ALIAS:
+                return new DeleteCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            case ClearCommand.COMMAND_WORD:
+                return new ClearCommand();
 
-        case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
+            case FindCommand.COMMAND_WORD:
+                return new FindCommandParser().parse(arguments);
 
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            case ListCommand.COMMAND_WORD:
+                return new ListCommand();
 
-        case HistoryCommand.COMMAND_WORD:
-            return new HistoryCommand();
+            case HistoryCommand.COMMAND_WORD:
+                return new HistoryCommand();
 
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
+            case ExitCommand.COMMAND_WORD:
+                return new ExitCommand();
 
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            case HelpCommand.COMMAND_WORD:
+                return new HelpCommand();
 
-        case UndoCommand.COMMAND_WORD:
-            return new UndoCommand();
+            case UndoCommand.COMMAND_WORD:
+                return new UndoCommand();
 
-        case RedoCommand.COMMAND_WORD:
-            return new RedoCommand();
-            
-        case ExportCommand.COMMAND_WORD:
-            return new ExportCommandParser().parse(arguments);
+            case RedoCommand.COMMAND_WORD:
+                return new RedoCommand();
 
-        default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            case ExportCommand.COMMAND_WORD:
+                return new ExportCommandParser().parse(arguments);
+
+            default:
+                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -84,6 +85,9 @@ public class AddressBookParser {
 
         case RedoCommand.COMMAND_WORD:
             return new RedoCommand();
+            
+        case ExportCommand.COMMAND_WORD:
+            return new ExportCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
@@ -19,7 +20,6 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
-import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -49,48 +49,48 @@ public class AddressBookParser {
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
 
-            case AddCommand.COMMAND_WORD:
-                return new AddCommandParser().parse(arguments);
+        case AddCommand.COMMAND_WORD:
+            return new AddCommandParser().parse(arguments);
 
-            case EditCommand.COMMAND_WORD:
-                return new EditCommandParser().parse(arguments);
+        case EditCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(arguments);
 
-            case SelectCommand.COMMAND_WORD:
-                return new SelectCommandParser().parse(arguments);
+        case SelectCommand.COMMAND_WORD:
+            return new SelectCommandParser().parse(arguments);
 
-            case DeleteCommand.COMMAND_WORD:
-            case DeleteCommand.COMMAND_ALIAS:
-                return new DeleteCommandParser().parse(arguments);
+        case DeleteCommand.COMMAND_WORD:
+        case DeleteCommand.COMMAND_ALIAS:
+            return new DeleteCommandParser().parse(arguments);
 
-            case ClearCommand.COMMAND_WORD:
-                return new ClearCommand();
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
 
-            case FindCommand.COMMAND_WORD:
-                return new FindCommandParser().parse(arguments);
+        case FindCommand.COMMAND_WORD:
+            return new FindCommandParser().parse(arguments);
 
-            case ListCommand.COMMAND_WORD:
-                return new ListCommand();
+        case ListCommand.COMMAND_WORD:
+            return new ListCommand();
 
-            case HistoryCommand.COMMAND_WORD:
-                return new HistoryCommand();
+        case HistoryCommand.COMMAND_WORD:
+            return new HistoryCommand();
 
-            case ExitCommand.COMMAND_WORD:
-                return new ExitCommand();
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
 
-            case HelpCommand.COMMAND_WORD:
-                return new HelpCommand();
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand();
 
-            case UndoCommand.COMMAND_WORD:
-                return new UndoCommand();
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
 
-            case RedoCommand.COMMAND_WORD:
-                return new RedoCommand();
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
 
-            case ExportCommand.COMMAND_WORD:
-                return new ExportCommandParser().parse(arguments);
+        case ExportCommand.COMMAND_WORD:
+            return new ExportCommandParser().parse(arguments);
 
-            default:
-                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,5 +12,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_GROUPTAG = new Prefix("g/");
+    public static final Prefix PREFIX_PATH = new Prefix("f/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -1,14 +1,17 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.ExportCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
 
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 
+/**
+ * Parses input arguments and creates a new ExportCommand object
+ */
 public class ExportCommandParser implements Parser<ExportCommand> {
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -20,11 +20,11 @@ public class ExportCommandParser implements Parser<ExportCommand> {
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
         }
-        
+
         Path filePath = ParserUtil.parsePath(argMultimap.getValue(PREFIX_PATH).get());
         return new ExportCommand(filePath);
     }
-    
+
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
      * {@code ArgumentMultimap}.

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+public class ExportCommandParser implements Parser<ExportCommand> {
+
+    @Override
+    public ExportCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_PATH);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_PATH)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+        
+        Path filePath = ParserUtil.parsePath(argMultimap.getValue(PREFIX_PATH).get());
+        return new ExportCommand(filePath);
+    }
+    
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}
+

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -127,8 +129,7 @@ public class ParserUtil {
         }
         return tagSet;
     }
-
-
+    
     /**
      * Parses a {@code String title} into a {@code Title}.
      * Leading and trailing whitespaces will be trimmed.
@@ -198,5 +199,15 @@ public class ParserUtil {
         members.forEach(parseList::add);
 
         return parseList;
+    }
+    
+    /**
+     * Parse {@code String filepath} into {@code Path}.
+     */
+    public static Path parsePath(String filepath) throws ParseException {
+        requireNonNull(filepath);
+        String trimmed = filepath.trim();
+        Path path = Paths.get(trimmed);
+        return path;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -129,7 +129,7 @@ public class ParserUtil {
         }
         return tagSet;
     }
-    
+
     /**
      * Parses a {@code String title} into a {@code Title}.
      * Leading and trailing whitespaces will be trimmed.
@@ -200,7 +200,7 @@ public class ParserUtil {
 
         return parseList;
     }
-    
+
     /**
      * Parse {@code String filepath} into {@code Path}.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,5 +1,6 @@
 package seedu.address.model;
 
+import java.nio.file.Path;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -96,4 +97,9 @@ public interface Model {
      * Saves the current address book state for undo/redo.
      */
     void commitAddressBook();
+
+    /**
+     * Export the current address book.
+     */
+    void exportAddressBook(Path filepath);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -12,6 +13,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
+import seedu.address.commons.events.model.AddressBookExportEvent;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 
@@ -143,7 +145,15 @@ public class ModelManager extends ComponentManager implements Model {
     public void commitAddressBook() {
         versionedAddressBook.commit();
     }
-
+    
+    // ================= Export/Import =======================================================================
+    
+    @Override
+    /** Raises an event to indicate the model to be exported */
+    public void exportAddressBook(Path filepath) {
+        raise(new AddressBookExportEvent(versionedAddressBook, filepath));
+    }
+    
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -145,15 +145,15 @@ public class ModelManager extends ComponentManager implements Model {
     public void commitAddressBook() {
         versionedAddressBook.commit();
     }
-    
+
     // ================= Export/Import =======================================================================
-    
+
     @Override
     /** Raises an event to indicate the model to be exported */
     public void exportAddressBook(Path filepath) {
         raise(new AddressBookExportEvent(versionedAddressBook, filepath));
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -37,7 +37,7 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
      * Raises {@link DataSavingExceptionEvent} if there was an error during saving.
      */
     void handleAddressBookChangedEvent(AddressBookChangedEvent abce);
-    
+
     /**
      * Export the current version of the Address Book to the hard disk.
      *   Creates the data file if it is missing.

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import seedu.address.commons.events.model.AddressBookChangedEvent;
+import seedu.address.commons.events.model.AddressBookExportEvent;
 import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -36,4 +37,11 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
      * Raises {@link DataSavingExceptionEvent} if there was an error during saving.
      */
     void handleAddressBookChangedEvent(AddressBookChangedEvent abce);
+    
+    /**
+     * Export the current version of the Address Book to the hard disk.
+     *   Creates the data file if it is missing.
+     * Raises {@link DataSavingExceptionEvent} if there was an error during saving.
+     */
+    void handleAddressBookExportEvent(AddressBookExportEvent abce);
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -10,6 +10,7 @@ import com.google.common.eventbus.Subscribe;
 import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.AddressBookChangedEvent;
+import seedu.address.commons.events.model.AddressBookExportEvent;
 import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -90,4 +91,14 @@ public class StorageManager extends ComponentManager implements Storage {
         }
     }
 
+    @Override
+    @Subscribe
+    public void handleAddressBookExportEvent(AddressBookExportEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event, "Exporting data and saving to file"));
+        try {
+            saveAddressBook(event.data, event.path);
+        } catch (IOException e) {
+            raise(new DataSavingExceptionEvent(e));
+        }
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -5,10 +5,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -161,6 +163,11 @@ public class AddCommandTest {
 
         @Override
         public void commitAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+   
+        @Override
+        public void exportAddressBook(Path filepath) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -165,7 +165,7 @@ public class AddCommandTest {
         public void commitAddressBook() {
             throw new AssertionError("This method should not be called.");
         }
-   
+
         @Override
         public void exportAddressBook(Path filepath) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.testutil.TestUtil;
+import seedu.address.ui.testutil.EventsCollectorRule;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code ExportCommand}.
+ */
+public class ExportCommandTest {
+    @Rule
+    public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+    private static final Path EXPORT_PATH = TestUtil.getFilePathInSandboxFolder("exportData.xml");
+    
+    @Test
+    public void execute_export_message_success() {
+        
+        ExportCommand exportCommand = new ExportCommand(EXPORT_PATH);
+        assertCommandSuccess(exportCommand, model, commandHistory, ExportCommand.MESSAGE_EXPORT_SUCCESS, expectedModel);
+        deleteFileIfExists(EXPORT_PATH);
+    }
+
+    /**
+     * Deletes the file at {@code filePath} if it exists.
+     */
+    private void deleteFileIfExists(Path filePath) {
+        try {
+            Files.deleteIfExists(filePath);
+        } catch (IOException ioe) {
+            throw new AssertionError(ioe);
+        }
+    }
+    
+    @After
+    /**
+     * Cleanup of file created in event of test case fails
+     */
+    public void cleanUp() {
+        deleteFileIfExists(EXPORT_PATH);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -1,8 +1,16 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -10,27 +18,22 @@ import seedu.address.model.UserPrefs;
 import seedu.address.testutil.TestUtil;
 import seedu.address.ui.testutil.EventsCollectorRule;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-
 /**
  * Contains integration tests (interaction with the Model) for {@code ExportCommand}.
  */
 public class ExportCommandTest {
+
+    private static final Path EXPORT_PATH = TestUtil.getFilePathInSandboxFolder("exportData.xml");
+
     @Rule
     public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private CommandHistory commandHistory = new CommandHistory();
-    private static final Path EXPORT_PATH = TestUtil.getFilePathInSandboxFolder("exportData.xml");
 
     @Test
-    public void execute_export_message_success() {
+    public void execute_export_success() {
 
         ExportCommand exportCommand = new ExportCommand(EXPORT_PATH);
         assertCommandSuccess(exportCommand, model, commandHistory, ExportCommand.MESSAGE_EXPORT_SUCCESS, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -28,10 +28,10 @@ public class ExportCommandTest {
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private CommandHistory commandHistory = new CommandHistory();
     private static final Path EXPORT_PATH = TestUtil.getFilePathInSandboxFolder("exportData.xml");
-    
+
     @Test
     public void execute_export_message_success() {
-        
+
         ExportCommand exportCommand = new ExportCommand(EXPORT_PATH);
         assertCommandSuccess(exportCommand, model, commandHistory, ExportCommand.MESSAGE_EXPORT_SUCCESS, expectedModel);
         deleteFileIfExists(EXPORT_PATH);
@@ -47,7 +47,7 @@ public class ExportCommandTest {
             throw new AssertionError(ioe);
         }
     }
-    
+
     @After
     /**
      * Cleanup of file created in event of test case fails

--- a/src/test/java/systemtests/ExportCommandSystemTest.java
+++ b/src/test/java/systemtests/ExportCommandSystemTest.java
@@ -18,24 +18,25 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
 import static org.junit.Assert.assertTrue;
 
 public class ExportCommandSystemTest extends AddressBookSystemTest {
-    
+
     private static final String EXPORT_FILE = "ExportData.xml";
     private static final Path EXPORT_PATH = Paths.get(EXPORT_FILE);
+
     @Test
     public void export() throws IOException {
         String command, failedMsg;
         Model expectedModel = getModel();
-        
+
         /* Case: export data to EXPORT_FILE with trailing whitespace-> export successful */
         command = ExportCommand.COMMAND_WORD + " " + PREFIX_PATH + " " + EXPORT_FILE + "   ";
-        
+
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
         assertFileExist(EXPORT_FILE);
         assertExportContentCorrect(EXPORT_PATH);
-        
+
         deleteFileIfExists(EXPORT_PATH);
-       
+
         /* Case: export data to EXPORT_FILE -> export successful */
         command = ExportCommand.COMMAND_WORD + " " + PREFIX_PATH + " " + EXPORT_FILE;
 
@@ -45,7 +46,7 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
         assertExportContentCorrect(EXPORT_PATH);
 
         deleteFileIfExists(EXPORT_PATH);
-        
+
         /* Case: export data without indicating filename -> rejected */
         command = ExportCommand.COMMAND_WORD;
         failedMsg = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE);
@@ -66,6 +67,7 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
      * Also verifies that the status bar remains unchanged, and the command box has the default style class, and the
      * selected card updated accordingly, depending on {@code cardStatus}.
+     *
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
     private void assertCommandSuccess(String command, Model expectedModel) {
@@ -84,6 +86,7 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
      * Also verifies that the browser url, selected card and status bar remain unchanged, and the command box has the
      * error style.
+     *
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
     private void assertCommandFailure(String command, String expectedResultMessage) {
@@ -95,7 +98,7 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
         assertCommandBoxShowsErrorStyle();
         assertStatusBarUnchanged();
     }
-    
+
     @After
     /**
      * Clean up file created in event of assertion failure.
@@ -117,6 +120,7 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
 
     /**
      * Assert if the Exported File exists.
+     *
      * @param filename filename
      */
     private void assertFileExist(String filename) {
@@ -125,8 +129,9 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
     }
 
     /**
-     * Assert if the exported address book is the same as the original saved address book by checking 
+     * Assert if the exported address book is the same as the original saved address book by checking
      * its content.
+     *
      * @param path path to the exported file
      * @throws IOException
      */
@@ -134,28 +139,26 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
         Path original = getDataFileLocation();
         Path export = path;
         final long size = Files.size(export);
-        
+
         if (size < 4096) {
             byte[] f1 = Files.readAllBytes(original);
             byte[] f2 = Files.readAllBytes(export);
-            boolean sameSize = Arrays.equals(f1,f2);
+            boolean sameSize = Arrays.equals(f1, f2);
             assertTrue(sameSize);
         }
 
         InputStream is1 = Files.newInputStream(original);
         InputStream is2 = Files.newInputStream(export);
-        
-        int i,j;
-        byte[] buffer1 = new byte[1024]; 
-        byte[] buffer2 = new byte[1024]; 
-        
+
+        int i, j;
+        byte[] buffer1 = new byte[1024];
+        byte[] buffer2 = new byte[1024];
+
         do {
             i = is1.read(buffer1);
             j = is2.read(buffer2);
-            
-            assertTrue(Arrays.equals(buffer1,buffer2));
+
+            assertTrue(Arrays.equals(buffer1, buffer2));
         } while ((i == j) && (i != -1));
-        
-        
     }
 }

--- a/src/test/java/systemtests/ExportCommandSystemTest.java
+++ b/src/test/java/systemtests/ExportCommandSystemTest.java
@@ -1,9 +1,8 @@
 package systemtests;
 
-import org.junit.After;
-import org.junit.Test;
-import seedu.address.logic.commands.ExportCommand;
-import seedu.address.model.Model;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,9 +12,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
-import static org.junit.Assert.assertTrue;
+import org.junit.After;
+import org.junit.Test;
+
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.model.Model;
+
 
 public class ExportCommandSystemTest extends AddressBookSystemTest {
 
@@ -24,7 +26,8 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
 
     @Test
     public void export() throws IOException {
-        String command, failedMsg;
+        String command;
+        String failedMsg;
         Model expectedModel = getModel();
 
         /* Case: export data to EXPORT_FILE with trailing whitespace-> export successful */
@@ -150,7 +153,8 @@ public class ExportCommandSystemTest extends AddressBookSystemTest {
         InputStream is1 = Files.newInputStream(original);
         InputStream is2 = Files.newInputStream(export);
 
-        int i, j;
+        int i;
+        int j;
         byte[] buffer1 = new byte[1024];
         byte[] buffer2 = new byte[1024];
 

--- a/src/test/java/systemtests/ExportCommandSystemTest.java
+++ b/src/test/java/systemtests/ExportCommandSystemTest.java
@@ -1,0 +1,161 @@
+package systemtests;
+
+import org.junit.After;
+import org.junit.Test;
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.model.Model;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
+import static org.junit.Assert.assertTrue;
+
+public class ExportCommandSystemTest extends AddressBookSystemTest {
+    
+    private static final String EXPORT_FILE = "ExportData.xml";
+    private static final Path EXPORT_PATH = Paths.get(EXPORT_FILE);
+    @Test
+    public void export() throws IOException {
+        String command, failedMsg;
+        Model expectedModel = getModel();
+        
+        /* Case: export data to EXPORT_FILE with trailing whitespace-> export successful */
+        command = ExportCommand.COMMAND_WORD + " " + PREFIX_PATH + " " + EXPORT_FILE + "   ";
+        
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+        assertFileExist(EXPORT_FILE);
+        assertExportContentCorrect(EXPORT_PATH);
+        
+        deleteFileIfExists(EXPORT_PATH);
+       
+        /* Case: export data to EXPORT_FILE -> export successful */
+        command = ExportCommand.COMMAND_WORD + " " + PREFIX_PATH + " " + EXPORT_FILE;
+
+        assertCommandSuccess(command, expectedModel);
+        assertSelectedCardUnchanged();
+        assertFileExist(EXPORT_FILE);
+        assertExportContentCorrect(EXPORT_PATH);
+
+        deleteFileIfExists(EXPORT_PATH);
+        
+        /* Case: export data without indicating filename -> rejected */
+        command = ExportCommand.COMMAND_WORD;
+        failedMsg = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE);
+        assertCommandFailure(command, failedMsg);
+
+        /* Case: export data without prefix -> rejected */
+        command = ExportCommand.COMMAND_WORD + " " + EXPORT_FILE;
+        failedMsg = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE);
+        assertCommandFailure(command, failedMsg);
+
+    }
+
+    /**
+     * Executes {@code command} and verifies that the command box displays an empty string, the result display
+     * box displays {@code ExportCommand#MESSAGE_EXPORT_SUCCESS} with the number of people in the filtered list,
+     * and the model related components equal to {@code expectedModel}.
+     * These verifications are done by
+     * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * Also verifies that the status bar remains unchanged, and the command box has the default style class, and the
+     * selected card updated accordingly, depending on {@code cardStatus}.
+     * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandSuccess(String command, Model expectedModel) {
+        String expectedResultMessage = ExportCommand.MESSAGE_EXPORT_SUCCESS;
+
+        executeCommand(command);
+        assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
+        assertCommandBoxShowsDefaultStyle();
+        assertStatusBarUnchanged();
+    }
+
+    /**
+     * Executes {@code command} and verifies that the command box displays {@code command}, the result display
+     * box displays {@code expectedResultMessage} and the model related components equal to the current model.
+     * These verifications are done by
+     * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * Also verifies that the browser url, selected card and status bar remain unchanged, and the command box has the
+     * error style.
+     * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandFailure(String command, String expectedResultMessage) {
+        Model expectedModel = getModel();
+
+        executeCommand(command);
+        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertSelectedCardUnchanged();
+        assertCommandBoxShowsErrorStyle();
+        assertStatusBarUnchanged();
+    }
+    
+    @After
+    /**
+     * Clean up file created in event of assertion failure.
+     */
+    public void cleanUp() {
+        deleteFileIfExists(EXPORT_PATH);
+    }
+
+    /**
+     * Deletes the file at {@code filePath} if it exists.
+     */
+    private void deleteFileIfExists(Path filePath) {
+        try {
+            Files.deleteIfExists(filePath);
+        } catch (IOException ioe) {
+            throw new AssertionError(ioe);
+        }
+    }
+
+    /**
+     * Assert if the Exported File exists.
+     * @param filename filename
+     */
+    private void assertFileExist(String filename) {
+        File tmpFile = new File(filename);
+        assertTrue(tmpFile.exists());
+    }
+
+    /**
+     * Assert if the exported address book is the same as the original saved address book by checking 
+     * its content.
+     * @param path path to the exported file
+     * @throws IOException
+     */
+    public void assertExportContentCorrect(Path path) throws IOException {
+        Path original = getDataFileLocation();
+        Path export = path;
+        final long size = Files.size(export);
+        
+        if (size < 4096) {
+            byte[] f1 = Files.readAllBytes(original);
+            byte[] f2 = Files.readAllBytes(export);
+            boolean sameSize = Arrays.equals(f1,f2);
+            assertTrue(sameSize);
+        }
+
+        InputStream is1 = Files.newInputStream(original);
+        InputStream is2 = Files.newInputStream(export);
+        
+        int i,j;
+        byte[] buffer1 = new byte[1024]; 
+        byte[] buffer2 = new byte[1024]; 
+        
+        do {
+            i = is1.read(buffer1);
+            j = is2.read(buffer2);
+            
+            assertTrue(Arrays.equals(buffer1,buffer2));
+        } while ((i == j) && (i != -1));
+        
+        
+    }
+}


### PR DESCRIPTION
The application can now handle `export` command.
Usage of `export` command is as follows:
```export f\filepath```

A new prefix `f\` has been added to aid recognition of filepath argument and will be used for future command implementation too.