### PR TITLE
Implement ImportCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -13,13 +15,10 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.storage.XmlAddressBookStorage;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
-
 /**
  * Import MeetingBook XML Files into MeetingBook
  */
-public class ImportCommand extends Command{
-    private static final Logger logger = LogsCenter.getLogger(XmlAddressBookStorage.class);
+public class ImportCommand extends Command {
     public static final String COMMAND_WORD = "import";
     public static final String MESSAGE_SUCCESS = "%s have been imported into MeetingBook.";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Import XML File to Meetingbook."
@@ -27,11 +26,10 @@ public class ImportCommand extends Command{
             + PREFIX_PATH + "FilePath\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_PATH + "backup";
-    public static final String MESSAGE_FAIL_DATA = "Data file not in the correct format. "
-            + "Will be starting with an empty AddressBook.";
-    public  static final String MESSAGE_FAIL_IO = "Problem while reading from the file. "
-            + "Will be starting with an empty AddressBook.";
-    public  static final String MESSAGE_FAIL_NOFILE = "File does not exists.";
+    public static final String MESSAGE_FAIL_DATA = "Data file not in the correct format. ";
+    public static final String MESSAGE_FAIL_NOFILE = "File does not exists.";
+
+    private static final Logger logger = LogsCenter.getLogger(XmlAddressBookStorage.class);
 
     private Path importPath;
 
@@ -50,13 +48,12 @@ public class ImportCommand extends Command{
             if (!importedAddressBook.isPresent()) {
                 return new CommandResult(MESSAGE_FAIL_NOFILE);
             }
-        }
-        catch (DataConversionException e) {
+        } catch (DataConversionException e) {
             logger.warning(MESSAGE_FAIL_DATA);
             return new CommandResult(MESSAGE_FAIL_DATA);
         } catch (IOException e) {
-            logger.warning(MESSAGE_FAIL_IO);
-            return new CommandResult(MESSAGE_FAIL_IO);
+            logger.warning(MESSAGE_FAIL_NOFILE);
+            return new CommandResult(MESSAGE_FAIL_NOFILE);
         }
 
         model.importAddressBook(importedAddressBook.get());

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,10 +1,17 @@
 package seedu.address.logic.commands;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-
-import java.nio.file.Path;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.storage.XmlAddressBookStorage;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
 
@@ -12,6 +19,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
  * Import MeetingBook XML Files into MeetingBook
  */
 public class ImportCommand extends Command{
+    private static final Logger logger = LogsCenter.getLogger(XmlAddressBookStorage.class);
     public static final String COMMAND_WORD = "import";
     public static final String MESSAGE_SUCCESS = "%s have been imported into MeetingBook.";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Import XML File to Meetingbook."
@@ -19,6 +27,11 @@ public class ImportCommand extends Command{
             + PREFIX_PATH + "FilePath\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_PATH + "backup";
+    public static final String MESSAGE_FAIL_DATA = "Data file not in the correct format. "
+            + "Will be starting with an empty AddressBook.";
+    public  static final String MESSAGE_FAIL_IO = "Problem while reading from the file. "
+            + "Will be starting with an empty AddressBook.";
+    public  static final String MESSAGE_FAIL_NOFILE = "File does not exists.";
 
     private Path importPath;
 
@@ -29,7 +42,25 @@ public class ImportCommand extends Command{
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
 
-        // TODO: Parse import file into existing MeetingBook
+        // TODO: Support Meeting
+        XmlAddressBookStorage importedXmlAddressStorage = new XmlAddressBookStorage(importPath);
+        Optional<ReadOnlyAddressBook> importedAddressBook;
+        try {
+            importedAddressBook = importedXmlAddressStorage.readAddressBook();
+            if (!importedAddressBook.isPresent()) {
+                return new CommandResult(MESSAGE_FAIL_NOFILE);
+            }
+        }
+        catch (DataConversionException e) {
+            logger.warning(MESSAGE_FAIL_DATA);
+            return new CommandResult(MESSAGE_FAIL_DATA);
+        } catch (IOException e) {
+            logger.warning(MESSAGE_FAIL_IO);
+            return new CommandResult(MESSAGE_FAIL_IO);
+        }
+
+        model.importAddressBook(importedAddressBook.get());
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_SUCCESS, importPath.toString()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+import java.nio.file.Path;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
+
+/**
+ * Import MeetingBook XML Files into MeetingBook
+ */
+public class ImportCommand extends Command{
+    public static final String COMMAND_WORD = "import";
+    public static final String MESSAGE_SUCCESS = "%s have been imported into MeetingBook.";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Import XML File to Meetingbook."
+            + "Parameters: "
+            + PREFIX_PATH + "FilePath\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_PATH + "backup";
+
+    private Path importPath;
+
+    public ImportCommand(Path filepath) {
+        importPath = filepath;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+
+        // TODO: Parse import file into existing MeetingBook
+        return new CommandResult(String.format(MESSAGE_SUCCESS, importPath.toString()));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.FilepathCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MeetCommand;
 import seedu.address.logic.commands.RedoCommand;
@@ -100,6 +101,9 @@ public class AddressBookParser {
 
         case FilepathCommand.COMMAND_WORD:
             return new FilepathCommandParser().parse(arguments);
+
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
+
+/**
+ * Parses input arguments and creates a new ExportCommand object
+ */
+public class ImportCommandParser implements Parser<ImportCommand> {
+
+    @Override
+    public ImportCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_PATH);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_PATH)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        }
+
+        Path filePath = ParserUtil.parsePath(argMultimap.getValue(PREFIX_PATH).get());
+        return new ImportCommand(filePath);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}
+

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -1,14 +1,13 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.ExportCommand;
-import seedu.address.logic.commands.ImportCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
 
 import java.nio.file.Path;
 import java.util.stream.Stream;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PATH;
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new ExportCommand object

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -223,8 +223,8 @@ public class AddressBook implements ReadOnlyAddressBook {
             return;
         }
         if (imported instanceof AddressBook) {
-            AddressBook importedBook = (AddressBook)imported;
-            Iterator<Person> personItr =  importedBook.persons.iterator();
+            AddressBook importedBook = (AddressBook) imported;
+            Iterator<Person> personItr = importedBook.persons.iterator();
             while (personItr.hasNext()) {
                 Person importPerson = personItr.next();
                 if (!hasPerson(importPerson)) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
@@ -212,6 +213,35 @@ public class AddressBook implements ReadOnlyAddressBook {
         return groups.asUnmodifiableObservableList();
     }
     // @@author
+
+    /**
+     * Merge another MeetingBook into current MeetingBook.
+     */
+    public void merge(ReadOnlyAddressBook imported) {
+        // If Both book contains same entries
+        if (equals(imported)) {
+            return;
+        }
+        if (imported instanceof AddressBook) {
+            AddressBook importedBook = (AddressBook)imported;
+            Iterator<Person> personItr =  importedBook.persons.iterator();
+            while (personItr.hasNext()) {
+                Person importPerson = personItr.next();
+                if (!hasPerson(importPerson)) {
+                    addPerson(importPerson);
+                }
+            }
+
+            Iterator<Group> groupItr = importedBook.groups.iterator();
+            while (groupItr.hasNext()) {
+                Group importGroup = groupItr.next();
+                if (!hasGroup(importGroup)) {
+                    addGroup(importGroup);
+                }
+            }
+
+        }
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -156,6 +156,11 @@ public interface Model {
     void exportAddressBook(Path filepath);
 
     /**
+     * Import the current address book.
+     */
+    void importAddressBook(ReadOnlyAddressBook importAddressBook);
+
+    /**
      * Change User Preferences.
      */
     void changeUserPrefs(Path filepath);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -20,6 +20,7 @@ import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.util.PersonPropertyComparator;
 import seedu.address.model.tag.Tag;
+import seedu.address.storage.XmlAddressBookStorage;
 
 
 /**
@@ -223,6 +224,12 @@ public class ModelManager extends ComponentManager implements Model {
         Path currentPath = userPrefs.getAddressBookFilePath();
         userPrefs.setAddressBookFilePath(filepath);
         raise(new UserPrefsChangeEvent(userPrefs, versionedAddressBook, currentPath, filepath));
+    }
+
+    @Override
+    public void importAddressBook(ReadOnlyAddressBook importedAddressBook) {
+        versionedAddressBook.merge(importedAddressBook);
+        indicateAddressBookChanged();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -20,7 +20,6 @@ import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.util.PersonPropertyComparator;
 import seedu.address.model.tag.Tag;
-import seedu.address.storage.XmlAddressBookStorage;
 
 
 /**

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.storage.XmlAddressBookStorage;
+import seedu.address.ui.testutil.EventsCollectorRule;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code ExportCommand}.
+ */
+public class ImportCommandTest {
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "XmlUtilTest");
+    private static final Path VALID_FILE = TEST_DATA_FOLDER.resolve("validAddressBook.xml");
+    private static final Path EMPTY_FILE = TEST_DATA_FOLDER.resolve("empty.xml");
+    private static final Path MISSING_FILE = TEST_DATA_FOLDER.resolve("missing.xml");
+
+    @Rule
+    public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_import_success() throws IOException, DataConversionException {
+        ImportCommand importCommand = new ImportCommand(VALID_FILE);
+        XmlAddressBookStorage expectedStorage = new XmlAddressBookStorage(VALID_FILE);
+        expectedModel.importAddressBook(expectedStorage.readAddressBook().get());
+        expectedModel.commitAddressBook();
+        assertCommandSuccess(importCommand, model, commandHistory,
+                String.format(ImportCommand.MESSAGE_SUCCESS, VALID_FILE.toString()), expectedModel);
+    }
+
+    @Test
+    public void execute_importDataFormatMismatchException_failure() {
+        ImportCommand importCommand = new ImportCommand(EMPTY_FILE);
+        assertCommandSuccess(importCommand, model, commandHistory, ImportCommand.MESSAGE_FAIL_DATA, expectedModel);
+    }
+
+    @Test
+    public void execute_importOptionalEmpty_failure() {
+        ImportCommand importCommand = new ImportCommand(MISSING_FILE);
+        assertCommandSuccess(importCommand, model, commandHistory, ImportCommand.MESSAGE_FAIL_NOFILE, expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MEETING_DESC_WEEKLY;
@@ -30,6 +31,7 @@ import seedu.address.logic.commands.FilepathCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MeetCommand;
 import seedu.address.logic.commands.RedoCommand;
@@ -130,6 +132,12 @@ public class AddressBookParserTest {
         }
     }
 
+    @Test
+    public void parseCommand_import() throws Exception {
+        assertTrue(parser.parseCommand(ImportCommand.COMMAND_WORD + " "
+                + CliSyntax.PREFIX_PATH + "test.xml") instanceof ImportCommand);
+
+    }
     @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -132,6 +132,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void importAddressBook(ReadOnlyAddressBook importAddressBook) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void changeUserPrefs(Path filepath) {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
Current MeetingBook does not have a feature for user to import other user MeetingBook data into their MeetingBook. This PR will allow the user to have import capabilities. 

Current Implementation of Import:
- Import command currently only supports adding of new Person. that is to say, if there exist duplicate person in the existing MeetingBook, it will not be added.
- Does not support Meeting yet.

Future Improvement planned:
- Support Meeting
- Able to let the user decide the behavior of import.
** Aggressive - If there is a duplicate, rename the Person by appending nonce to make it unique so that MeetingBook can add the new imported Person.
** Soft - If there is a duplicate, do not add.
** Replace - If there is a duplicate, replace with new.