### PR TITLE
Fix meeting pane UI not updated when using meet command, UI update

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,6 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_INVALID_GROUP_DISPLAYED_INDEX = "The group index provided is invalid";
+    public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid";
     public static final String MESSAGE_GROUP_NOT_FOUND = "The specified group does not exists";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_PERSONS_SORTED_OVERVIEW = "List sorted by %s!";

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -5,6 +5,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.group.Group;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 
 /**
@@ -28,6 +29,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the sorted list of persons */
     ObservableList<Person> getSortedPersonList();
+
+    /** Returns an unmodifiable view of the filtered list of meetings */
+    ObservableList<Meeting> getFilteredMeetingList();
 
     /** Returns the list of input entered by the user, encapsulated in a {@code ListElementPointer} object */
     ListElementPointer getHistorySnapshot();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -12,6 +12,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.group.Group;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 
 /**
@@ -54,6 +55,11 @@ public class LogicManager extends ComponentManager implements Logic {
     @Override
     public ObservableList<Person> getSortedPersonList() {
         return model.getSortedPersonList();
+    }
+
+    @Override
+    public ObservableList<Meeting> getFilteredMeetingList() {
+        return model.getFilteredMeetingList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_GROUPS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MEETINGS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.logic.CommandHistory;
@@ -52,10 +53,17 @@ public class ListCommand extends Command {
             model.updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
             return new CommandResult(MESSAGE_SUCCESS_GROUP);
         case MEETING:
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            return new CommandResult(MESSAGE_SUCCESS_PERSON);
+            model.updateFilteredMeetingList(PREDICATE_SHOW_ALL_MEETINGS);
+            return new CommandResult(MESSAGE_SUCCESS_MEETING);
         default:
             throw new IllegalStateException();
         }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof ListCommand // instanceof handles nulls
+            && listCommandType.equals(((ListCommand) other).listCommandType)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON;
 
 import java.util.Arrays;
 import java.util.List;
@@ -10,11 +13,13 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.events.ui.JumpToGroupListRequestEvent;
 import seedu.address.commons.events.ui.JumpToListRequestEvent;
+import seedu.address.commons.events.ui.JumpToMeetingListRequestEvent;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.group.Group;
 import seedu.address.model.group.util.GroupContainsPersonPredicate;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 
 /**
@@ -33,11 +38,13 @@ public class SelectCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Selects the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Parameters: [" + PREFIX_GROUP + " or " + PREFIX_MEETING + " or "
+                            + PREFIX_PERSON + "]INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " g/1";
 
     public static final String MESSAGE_SELECT_PERSON_SUCCESS = "Selected Person: %1$s";
     public static final String MESSAGE_SELECT_GROUP_SUCCESS = "Selected Group: %1$s";
+    public static final String MESSAGE_SELECT_MEETING_SUCCESS = "Selected Meeting: %1$s";
 
     private final Index targetIndex;
     private final SelectCommandType selectType;
@@ -63,7 +70,7 @@ public class SelectCommand extends Command {
             final String[] keywords = { group.getTitle().fullTitle };
             model.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(keywords[0])));
             return new CommandResult(String.format(MESSAGE_SELECT_GROUP_SUCCESS, targetIndex.getOneBased()));
-        } else {
+        } else if (selectType == SelectCommandType.PERSON) {
             List<Person> filteredPersonList = model.getFilteredPersonList();
 
             if (targetIndex.getZeroBased() >= filteredPersonList.size()) {
@@ -72,6 +79,15 @@ public class SelectCommand extends Command {
 
             EventsCenter.getInstance().post(new JumpToListRequestEvent(targetIndex));
             return new CommandResult(String.format(MESSAGE_SELECT_PERSON_SUCCESS, targetIndex.getOneBased()));
+        } else {
+            List<Meeting> filteredMeetingList = model.getFilteredMeetingList();
+
+            if (targetIndex.getZeroBased() >= filteredMeetingList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+            }
+
+            EventsCenter.getInstance().post(new JumpToMeetingListRequestEvent(targetIndex));
+            return new CommandResult(String.format(MESSAGE_SELECT_MEETING_SUCCESS, targetIndex.getOneBased()));
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -18,6 +18,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.group.Group;
+import seedu.address.model.group.util.GroupContainsMeetingPredicate;
 import seedu.address.model.group.util.GroupContainsPersonPredicate;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
@@ -69,6 +70,7 @@ public class SelectCommand extends Command {
             Group group = filteredGroupList.get(targetIndex.getZeroBased());
             final String[] keywords = { group.getTitle().fullTitle };
             model.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(keywords[0])));
+            model.updateFilteredMeetingList(new GroupContainsMeetingPredicate(Arrays.asList(group)));
             return new CommandResult(String.format(MESSAGE_SELECT_GROUP_SUCCESS, targetIndex.getOneBased()));
         } else if (selectType == SelectCommandType.PERSON) {
             List<Person> filteredPersonList = model.getFilteredPersonList();

--- a/src/main/java/seedu/address/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SelectCommand.java
@@ -68,8 +68,7 @@ public class SelectCommand extends Command {
 
             EventsCenter.getInstance().post(new JumpToGroupListRequestEvent(targetIndex));
             Group group = filteredGroupList.get(targetIndex.getZeroBased());
-            final String[] keywords = { group.getTitle().fullTitle };
-            model.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(keywords[0])));
+            model.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(group)));
             model.updateFilteredMeetingList(new GroupContainsMeetingPredicate(Arrays.asList(group)));
             return new CommandResult(String.format(MESSAGE_SELECT_GROUP_SUCCESS, targetIndex.getOneBased()));
         } else if (selectType == SelectCommandType.PERSON) {

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -17,15 +17,11 @@ public class CliSyntax {
     public static final Prefix PREFIX_TIMESTAMP = new Prefix("t/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_LOCATION = new Prefix("l/");
-
+    public static final Prefix PREFIX_PERSON = new Prefix("p/");
+    public static final Prefix PREFIX_MEETING = new Prefix("m/");
 
     /* Prefix definitions for FindCommandParser */
     public static final Prefix PREFIX_ALL = new Prefix("a/");
     public static final Prefix PREFIX_SOME = new Prefix("s/");
     public static final Prefix PREFIX_NONE = new Prefix("n/");
-
-    /* Prefix definitions for SelectCommandParser */
-    public static final Prefix PREFIX_PERSON = new Prefix("p/");
-    public static final Prefix PREFIX_GROUP = new Prefix("g/");
-    public static final Prefix PREFIX_MEETING = new Prefix("m/");
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,7 +13,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_GROUPTAG = new Prefix("g/");
     public static final Prefix PREFIX_PATH = new Prefix("f/");
-    public static final Prefix PREFIX_PERSON = new Prefix("p/");
     public static final Prefix PREFIX_TIMESTAMP = new Prefix("t/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_LOCATION = new Prefix("l/");
@@ -24,4 +23,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_SOME = new Prefix("s/");
     public static final Prefix PREFIX_NONE = new Prefix("n/");
 
+    /* Prefix definitions for SelectCommandParser */
+    public static final Prefix PREFIX_PERSON = new Prefix("p/");
+    public static final Prefix PREFIX_GROUP = new Prefix("g/");
+    public static final Prefix PREFIX_MEETING = new Prefix("m/");
 }

--- a/src/main/java/seedu/address/logic/parser/SelectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SelectCommandParser.java
@@ -1,7 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUPTAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON;
 
 import java.util.Optional;
@@ -23,29 +24,56 @@ public class SelectCommandParser implements Parser<SelectCommand> {
      */
     public SelectCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_GROUPTAG, PREFIX_PERSON);
+                ArgumentTokenizer.tokenize(args, PREFIX_GROUP, PREFIX_PERSON, PREFIX_MEETING);
 
-        if (!isOneOfThePrefixesPresent(argMultimap, PREFIX_GROUPTAG, PREFIX_PERSON)
+        if (!isOneOfThePrefixesPresent(argMultimap, PREFIX_GROUP, PREFIX_PERSON, PREFIX_MEETING)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
         }
 
         try {
-            Optional<String> option = argMultimap.getValue(PREFIX_GROUPTAG);
-            String indexString;
-            SelectCommand.SelectCommandType selectOption;
-            if (option.isPresent()) {
-                indexString = option.get();
-                selectOption = SelectCommand.SelectCommandType.GROUP;
-            } else {
-                indexString = argMultimap.getValue(PREFIX_PERSON).get();
-                selectOption = SelectCommand.SelectCommandType.PERSON;
-            }
-            Index index = ParserUtil.parseIndex(indexString);
+            SelectCommand.SelectCommandType selectOption = parseSelectCommandType(argMultimap);
+            Index index = parseSelectIndex(argMultimap, selectOption);
             return new SelectCommand(index, selectOption);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+    /**
+     * Returns the {@code SelectCommand.SelectCommandType} from user input.
+     * @throws ParseException if the prefix does not exist
+     */
+    private SelectCommand.SelectCommandType parseSelectCommandType(ArgumentMultimap argumentMultimap)
+        throws ParseException {
+
+        if (argumentMultimap.getValue(PREFIX_GROUP).isPresent()) {
+            return SelectCommand.SelectCommandType.GROUP;
+        } else if (argumentMultimap.getValue(PREFIX_MEETING).isPresent()) {
+            return SelectCommand.SelectCommandType.MEETING;
+        } else if (argumentMultimap.getValue(PREFIX_PERSON).isPresent()) {
+            return SelectCommand.SelectCommandType.PERSON;
+        } else {
+            throw new ParseException("Unknown prefix");
+        }
+    }
+
+    /**
+     * Returns the index from user input based on the {@code selectType}
+     * @throws ParseException if the prefix does not exist
+     */
+    private Index parseSelectIndex(ArgumentMultimap argumentMultimap, SelectCommand.SelectCommandType selectType)
+        throws ParseException {
+        switch (selectType) {
+        case GROUP:
+            return ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_GROUP).get());
+        case MEETING:
+            return ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_MEETING).get());
+        case PERSON:
+            return ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_PERSON).get());
+        default:
+            throw new ParseException("Unknown prefix");
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/SelectCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SelectCommandParser.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON;
 
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -5,10 +5,13 @@ import static java.util.Objects.requireNonNull;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.group.Group;
 import seedu.address.model.group.UniqueGroupList;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.UniqueMeetingList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -23,6 +26,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     // @@author Derek-Hardy
     private final UniqueGroupList groups;
 
+    private final UniqueMeetingList meetings;
+
     /*
      * The 'unusual' code block below is an non-static initialization block, sometimes used to avoid duplication
      * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
@@ -33,6 +38,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     {
         persons = new UniquePersonList();
         groups = new UniqueGroupList();
+        meetings = new UniqueMeetingList();
     }
     // @@author
 
@@ -63,6 +69,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setGroups(List<Group> groups) {
         this.groups.setGroups(groups);
+        meetings.setMeetings(groups.stream().map(Group::getMeeting).collect(Collectors.toList()));
     }
     // @@author
 
@@ -145,6 +152,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         target.clearMembers();
         editedGroup.setUpMembers();
 
+        meetings.setMeeting(target.getMeeting(), editedGroup.getMeeting());
         groups.setGroup(target, editedGroup);
     }
 
@@ -166,6 +174,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void removeGroup(Group group) {
         requireNonNull(group);
         group.clearMembers();
+        meetings.remove(group.getMeeting());
         groups.remove(group);
     }
     // @@author
@@ -175,7 +184,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public String toString() {
         return persons.asUnmodifiableObservableList().size() + " persons, "
-                + groups.asUnmodifiableObservableList().size() + " groups";
+                + groups.asUnmodifiableObservableList().size() + " groups, "
+                + meetings.asUnmodifiableObservableList().size() + " meetings";
         // TODO: refine later
     }
 
@@ -190,6 +200,12 @@ public class AddressBook implements ReadOnlyAddressBook {
         return groups.asUnmodifiableObservableList();
     }
     // @@author
+
+
+    @Override
+    public ObservableList<Meeting> getMeetingList() {
+        return meetings.asUnmodifiableObservableList();
+    }
 
     /**
      * Merge another MeetingBook into current MeetingBook.

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -121,6 +121,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void addGroup(Group group) {
         groups.add(group);
+        if (group.getMeeting() != null) {
+            meetings.add(group.getMeeting());
+        }
     }
 
     /**
@@ -174,7 +177,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     public void removeGroup(Group group) {
         requireNonNull(group);
         group.clearMembers();
-        meetings.remove(group.getMeeting());
+        if (group.getMeeting() != null) {
+            meetings.remove(group.getMeeting());
+        }
         groups.remove(group);
     }
     // @@author

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -127,6 +127,18 @@ public interface Model {
      */
     ObservableList<Person> getSortedPersonList();
 
+
+    /**
+     * Updates the filter of the filtered meeting list to filter by the given {@code predicate}
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredMeetingList(Predicate<Meeting> predicate);
+
+    /**
+     * @return An unmodifiable view of the filtered meeting list
+     */
+    ObservableList<Meeting> getFilteredMeetingList();
+
     /**
      * Updates the sorting of the sorted person list to sort by the given {@code comparator}.
      * @param personPropertyComparator The comparator to sort the list by.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -17,6 +17,7 @@ import seedu.address.commons.events.model.AddressBookChangedEvent;
 import seedu.address.commons.events.model.AddressBookExportEvent;
 import seedu.address.commons.events.model.UserPrefsChangeEvent;
 import seedu.address.model.group.Group;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.util.PersonPropertyComparator;
 
@@ -30,6 +31,7 @@ public class ModelManager extends ComponentManager implements Model {
     private final VersionedAddressBook versionedAddressBook;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Group> filteredGroups;
+    private final FilteredList<Meeting> filteredMeetings;
     private final UserPrefs userPrefs;
     private final SortedList<Person> sortedPersons;
 
@@ -45,6 +47,7 @@ public class ModelManager extends ComponentManager implements Model {
         versionedAddressBook = new VersionedAddressBook(addressBook);
         filteredPersons = new FilteredList<>(versionedAddressBook.getPersonList());
         filteredGroups = new FilteredList<>(versionedAddressBook.getGroupList());
+        filteredMeetings = new FilteredList<>(versionedAddressBook.getMeetingList());
         this.userPrefs = userPrefs;
         sortedPersons = new SortedList<>(filteredPersons);
     }
@@ -176,6 +179,17 @@ public class ModelManager extends ComponentManager implements Model {
     public void updateSortedPersonList(PersonPropertyComparator personPropertyComparator) {
         requireNonNull(personPropertyComparator);
         sortedPersons.setComparator(personPropertyComparator.getComparator());
+    }
+
+    @Override
+    public ObservableList<Meeting> getFilteredMeetingList() {
+        return FXCollections.unmodifiableObservableList(filteredMeetings);
+    }
+
+    @Override
+    public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
+        requireNonNull(predicate);
+        filteredMeetings.setPredicate(predicate);
     }
 
     //=========== Undo/Redo =================================================================================

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.group.Group;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 
 /**
@@ -21,4 +22,8 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Group> getGroupList();
 
+    /**
+     * Returns an unmodifiable view of the meeting list.
+     */
+    ObservableList<Meeting> getMeetingList();
 }

--- a/src/main/java/seedu/address/model/group/util/GroupContainsMeetingPredicate.java
+++ b/src/main/java/seedu/address/model/group/util/GroupContainsMeetingPredicate.java
@@ -1,0 +1,35 @@
+package seedu.address.model.group.util;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.group.Group;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Tests that a {@code Group}'s {@code Meeting} matches any of the groups given.
+ * {@author jeffreyooi}
+ */
+public class GroupContainsMeetingPredicate implements Predicate<Meeting> {
+    private final List<Group> groups;
+
+    public GroupContainsMeetingPredicate(List<Group> groups) {
+        this.groups = groups;
+    }
+
+    @Override
+    public boolean test(Meeting meeting) {
+        if (meeting == null) {
+            return false;
+        }
+        return groups.stream().filter(group -> group.getMeeting() != null)
+            .anyMatch(group -> group.getMeeting().isSameMeeting(meeting));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+            || (other instanceof GroupContainsMeetingPredicate
+            && groups.equals(((GroupContainsMeetingPredicate) other).groups));
+    }
+}

--- a/src/main/java/seedu/address/model/group/util/GroupContainsPersonPredicate.java
+++ b/src/main/java/seedu/address/model/group/util/GroupContainsPersonPredicate.java
@@ -1,14 +1,10 @@
 package seedu.address.model.group.util;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
-import seedu.address.model.tag.Tag;
 
 /**
  * Tests that a {@code Person}'s {@code Group} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/group/util/GroupContainsPersonPredicate.java
+++ b/src/main/java/seedu/address/model/group/util/GroupContainsPersonPredicate.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 
@@ -14,22 +15,22 @@ import seedu.address.model.tag.Tag;
  * {@author jeffreyooi}
  */
 public class GroupContainsPersonPredicate implements Predicate<Person> {
-    private final List<String> keywords;
+    private final List<Group> groups;
 
-    public GroupContainsPersonPredicate(List<String> keywords) {
-        this.keywords = keywords;
+    public GroupContainsPersonPredicate(List<Group> groups) {
+        this.groups = groups;
     }
 
     @Override
     public boolean test(Person person) {
-        Set<String> groupNames = person.getGroupTags().stream().map(Tag::getTagName).collect(Collectors.toSet());
-        return !Collections.disjoint(groupNames, keywords);
+        return groups.stream().filter(group -> group.getMembersView().size() > 0)
+            .anyMatch(group -> group.getMembersView().contains(person));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this
                 || (other instanceof GroupContainsPersonPredicate
-                && keywords.equals(((GroupContainsPersonPredicate) other).keywords));
+                && groups.equals(((GroupContainsPersonPredicate) other).groups));
     }
 }

--- a/src/main/java/seedu/address/model/group/util/GroupTitleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/group/util/GroupTitleContainsKeywordsPredicate.java
@@ -8,7 +8,6 @@ import seedu.address.model.group.Group;
 
 /**
  * Tests that a {@code Group}'s {@code Title} matches any of the keywords given.
- * TODO: change to Group class instead of Tag when group is properly implemented
  * {@author jeffreyooi}
  */
 public class GroupTitleContainsKeywordsPredicate implements Predicate<Group> {

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -1,0 +1,104 @@
+package seedu.address.model.meeting;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.group.Group;
+import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
+import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
+
+/**
+ * A list of meetings that does not allow nulls and is paired with groups that holds it.
+ * A meeting is considered duplicate if there exist another meeting that belongs to the same owner and both have same
+ * identity fields. The identities are compared by {@code Meeting#isSameMeeting(Meeting)}.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * {@author jeffreyooi}
+ */
+public class UniqueMeetingList implements Iterable<Meeting> {
+
+    private final ObservableList<Meeting> internalList = FXCollections.observableArrayList();
+
+    /**
+     * Returns true if the list contains an equivalent meeting as the given argument.
+     */
+    public boolean contains(Meeting toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameMeeting);
+    }
+
+    /**
+     * Adds a meeting to the list.
+     * The meeting can be already exist in the list but they belong to different groups.
+     * To identify, we need to check who owns the meeting.
+     */
+    public void add(Meeting toAdd) {
+        requireAllNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicateMeetingException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the meeting {@code target} in the map with {@code editedMeeting}.
+     * {@code target} must exist in the map.
+     * The meeting identity of {@code editedMeeting} must not be the same as another existing meeting that has the same
+     * owner.
+     */
+    public void setMeeting(Meeting target, Meeting editedMeeting) {
+        int index = -1;
+        if (target != null) {
+            index = internalList.indexOf(target);
+            internalList.remove(target);
+        }
+
+        if (editedMeeting != null) {
+            if (index == -1) {
+                index = internalList.size() - 1;
+            }
+            internalList.add(index, editedMeeting);
+        }
+    }
+
+    /**
+     * Removes the equivalent meeting from the map.
+     * The meeting must exist in the map.
+     */
+    public void remove(Meeting toRemove) {
+        requireAllNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new MeetingNotFoundException();
+        }
+    }
+
+    /**
+     * Creates a list and return as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Meeting> asUnmodifiableObservableList() {
+        return FXCollections.unmodifiableObservableList(internalList);
+    }
+
+    public void setMeetings(List<Meeting> meetings) {
+        requireNonNull(meetings);
+        internalList.setAll(meetings);
+    }
+
+    @Override
+    public Iterator<Meeting> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UniqueMeetingList // instanceof handles nulls
+                && internalList.equals(((UniqueMeetingList) other).internalList));
+    }
+}

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
 import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
 
 /**
@@ -35,13 +34,10 @@ public class UniqueMeetingList implements Iterable<Meeting> {
     /**
      * Adds a meeting to the list.
      * The meeting can be already exist in the list but they belong to different groups.
-     * To identify, we need to check who owns the meeting.
+     * TODO find a way to identify meetings of same fields but belong to different groups
      */
     public void add(Meeting toAdd) {
         requireAllNonNull(toAdd);
-        if (contains(toAdd)) {
-            throw new DuplicateMeetingException();
-        }
         internalList.add(toAdd);
     }
 
@@ -60,9 +56,10 @@ public class UniqueMeetingList implements Iterable<Meeting> {
 
         if (editedMeeting != null) {
             if (index == -1) {
-                index = internalList.size() - 1;
+                internalList.add(editedMeeting);
+            } else {
+                internalList.add(index, editedMeeting);
             }
-            internalList.add(index, editedMeeting);
         }
     }
 

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.model.group.Group;
 import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
 import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
 

--- a/src/main/java/seedu/address/model/meeting/exceptions/DuplicateMeetingException.java
+++ b/src/main/java/seedu/address/model/meeting/exceptions/DuplicateMeetingException.java
@@ -1,0 +1,14 @@
+package seedu.address.model.meeting.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Meetings
+ * (Meetings are considered duplicates if they belong to the same group and have the same identity).
+ *
+ * {@author jeffreyooi}
+ */
+public class DuplicateMeetingException extends RuntimeException {
+
+    public DuplicateMeetingException() {
+        super("Operation would result in duplicate meetings");
+    }
+}

--- a/src/main/java/seedu/address/model/meeting/exceptions/MeetingNotFoundException.java
+++ b/src/main/java/seedu/address/model/meeting/exceptions/MeetingNotFoundException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.meeting.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified meeting.
+ *
+ * {@author jeffreyooi}
+ */
+public class MeetingNotFoundException extends RuntimeException {
+    public MeetingNotFoundException() {
+        super("Meeting does not exist");
+    }
+}

--- a/src/main/java/seedu/address/model/meeting/util/MeetingTitleContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/meeting/util/MeetingTitleContainsKeywordPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.meeting.util;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Tests that a {@code Meeting}'s {@code Title} matches the keywords given.
+ */
+public class MeetingTitleContainsKeywordPredicate implements Predicate<Meeting> {
+    private final List<String> keywords;
+
+    public MeetingTitleContainsKeywordPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Meeting meeting) {
+        return keywords.stream()
+            .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(meeting.getTitle().fullTitle, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+            || (other instanceof MeetingTitleContainsKeywordPredicate
+            && keywords.equals(((MeetingTitleContainsKeywordPredicate) other).keywords));
+    }
+}

--- a/src/main/java/seedu/address/ui/GroupCard.java
+++ b/src/main/java/seedu/address/ui/GroupCard.java
@@ -45,7 +45,7 @@ public class GroupCard extends UiPart<Region> {
         String descriptionString = description != null ? description.statement : "";
         groupDescription.setText(descriptionString);
         Meeting meeting = group.getMeeting();
-        String meetingString = meeting != null ? meeting.getTitle().fullTitle : "null";
+        String meetingString = meeting != null ? meeting.getTitle().fullTitle : "";
         groupMeeting.setText(meetingString);
         int membersCount = group.getMembersView().size();
         memberCount.setText(String.format("%d", membersCount));

--- a/src/main/java/seedu/address/ui/InformationDisplay.java
+++ b/src/main/java/seedu/address/ui/InformationDisplay.java
@@ -1,19 +1,13 @@
 package seedu.address.ui;
 
-import java.util.List;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
-import seedu.address.model.group.Group;
-import seedu.address.model.meeting.Meeting;
 
 /**
  * The UI component that displays information of groups, meetings and persons in 3 horizontal panes.

--- a/src/main/java/seedu/address/ui/InformationDisplay.java
+++ b/src/main/java/seedu/address/ui/InformationDisplay.java
@@ -59,10 +59,7 @@ public class InformationDisplay extends UiPart<Region> {
         personListPanel = new PersonListPanel(logic.getSortedPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
-        List<Meeting> meetingList = logic.getFilteredGroupList().stream()
-            .map(Group::getMeeting).collect(Collectors.toList());
-        ObservableList<Meeting> meetingObservableList = FXCollections.observableList(meetingList);
-        meetingListPanel = new MeetingListPanel(meetingObservableList);
+        meetingListPanel = new MeetingListPanel(logic.getFilteredMeetingList());
         meetingListPanelPlaceholder.getChildren().add(meetingListPanel.getRoot());
     }
 }

--- a/src/main/resources/view/GroupListCard.fxml
+++ b/src/main/resources/view/GroupListCard.fxml
@@ -29,7 +29,14 @@
       </HBox>
          <Label fx:id="groupDescription" styleClass="cell_small_label" text="\$description" />
          <Label fx:id="groupMeeting" styleClass="cell_small_label" text="\$meeting" />
-         <Label fx:id="memberCount" styleClass="cell_small_label" text="\$memberCount" />
+        <HBox spacing="5.0" alignment="CENTER_LEFT">
+            <Label fx:id="member" styleClass="cell_small_label" text="Group size: ">
+                <minWidth>
+                    <Region fx:constant="USE_PREF_SIZE" />
+                </minWidth>
+            </Label>
+            <Label fx:id="memberCount" styleClass="cell_small_label" text="\$memberCount" />
+        </HBox>
        <padding>
           <Insets bottom="5.0" left="15.0" right="5.0" top="5.0" />
        </padding>

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
@@ -26,6 +27,8 @@ import seedu.address.model.Model;
 import seedu.address.model.group.Group;
 import seedu.address.model.group.util.GroupContainsPersonPredicate;
 import seedu.address.model.group.util.GroupTitleContainsKeywordsPredicate;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.util.MeetingTitleContainsKeywordPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.util.NameContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -177,6 +180,24 @@ public class CommandTestUtil {
             Collections.emptyList(), Arrays.asList(splitName[0]), Collections.emptyList()));
 
         assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered meeting list to show only the meeting at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showMeetingAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredMeetingList().size());
+
+        Meeting meeting = model.getFilteredMeetingList().get(targetIndex.getZeroBased());
+        final String[] splitName = meeting.getTitle().fullTitle.split("\\s+");
+        model.updateFilteredMeetingList(new MeetingTitleContainsKeywordPredicate(Arrays.asList(splitName[0])));
+
+        /**
+         * TODO this is a temp hack because there may be multiple meetings with same identities, will have to wait for
+         * the issue is rectified
+         */
+        assertNotEquals(0, model.getFilteredMeetingList().size());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -198,7 +198,7 @@ public class CommandTestUtil {
         Group group = model.getFilteredGroupList().get(targetIndex.getZeroBased());
         final String[] splitGroupTitle = { group.getTitle().fullTitle };
         model.updateFilteredGroupList(new GroupTitleContainsKeywordsPredicate(Arrays.asList(splitGroupTitle[0])));
-        model.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(splitGroupTitle[0])));
+        model.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(group)));
         assertEquals(1, model.getFilteredGroupList().size());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -63,7 +63,7 @@ public class ListCommandTest {
         Group group = expectedModel.getFilteredGroupList().get(INDEX_FIRST_GROUP.getZeroBased());
         final String[] groupTitle = { group.getTitle().fullTitle };
         expectedModel.updateFilteredGroupList(new GroupTitleContainsKeywordsPredicate(Arrays.asList(groupTitle[0])));
-        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(groupTitle[0])));
+        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(group)));
 
         assertCommandSuccess(new ListCommand(ListCommand.ListCommandType.GROUP), model, commandHistory,
             ListCommand.MESSAGE_SUCCESS_GROUP, expectedModel);
@@ -83,6 +83,6 @@ public class ListCommandTest {
         Group group = expectedModel.getFilteredGroupList().get(INDEX_FIRST_GROUP.getZeroBased());
         final String[] groupTitle = { group.getTitle().fullTitle };
         expectedModel.updateFilteredGroupList(new GroupTitleContainsKeywordsPredicate(Arrays.asList(groupTitle[0])));
-        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(groupTitle[0])));
+        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(group)));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -68,4 +68,21 @@ public class ListCommandTest {
         assertCommandSuccess(new ListCommand(ListCommand.ListCommandType.GROUP), model, commandHistory,
             ListCommand.MESSAGE_SUCCESS_GROUP, expectedModel);
     }
+
+    @Test
+    public void execute_meetingListIsNotFiltered_showsSameMeetingList() {
+        assertCommandSuccess(new ListCommand(ListCommand.ListCommandType.MEETING), model, commandHistory,
+            ListCommand.MESSAGE_SUCCESS_MEETING, expectedModel);
+    }
+
+    @Test
+    public void execute_meetingListIsFiltered_showsEverything() {
+        // One way to filter the meeting list is to select the group
+        showGroupAtIndex(model, INDEX_FIRST_GROUP);
+
+        Group group = expectedModel.getFilteredGroupList().get(INDEX_FIRST_GROUP.getZeroBased());
+        final String[] groupTitle = { group.getTitle().fullTitle };
+        expectedModel.updateFilteredGroupList(new GroupTitleContainsKeywordsPredicate(Arrays.asList(groupTitle[0])));
+        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(groupTitle[0])));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -112,18 +112,15 @@ public class SelectCommandTest {
         Index lastGroupIndex = Index.fromOneBased(model.getFilteredGroupList().size());
 
         Group group = expectedModel.getFilteredGroupList().get(INDEX_FIRST_GROUP.getZeroBased());
-        final String[] keywords = { group.getTitle().fullTitle };
-        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(keywords[0])));
+        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(group)));
         assertExecutionSuccess(INDEX_FIRST_GROUP, SelectCommand.SelectCommandType.GROUP);
 
         group = expectedModel.getFilteredGroupList().get(INDEX_THIRD_GROUP.getZeroBased());
-        keywords[0] = group.getTitle().fullTitle;
-        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(keywords[0])));
+        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(group)));
         assertExecutionSuccess(INDEX_THIRD_GROUP, SelectCommand.SelectCommandType.GROUP);
 
         group = expectedModel.getFilteredGroupList().get(lastGroupIndex.getZeroBased());
-        keywords[0] = group.getTitle().fullTitle;
-        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(keywords[0])));
+        expectedModel.updateFilteredPersonList(new GroupContainsPersonPredicate(Arrays.asList(group)));
         assertExecutionSuccess(lastGroupIndex, SelectCommand.SelectCommandType.GROUP);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListCommandParserTest.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.ListCommand;
+
+/**
+ * Test scope: similar to {@code DeleteCommandParserTest}
+ * {@author jeffreyooi}
+ */
+public class ListCommandParserTest {
+
+    private ListCommandParser parser = new ListCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsListPersonCommand() {
+        assertParseSuccess(parser, " person", new ListCommand(ListCommand.ListCommandType.PERSON));
+        assertParseSuccess(parser, " p", new ListCommand(ListCommand.ListCommandType.PERSON));
+    }
+
+    @Test
+    public void parse_validArgs_returnsListGroupCommand() {
+        assertParseSuccess(parser, " group", new ListCommand(ListCommand.ListCommandType.GROUP));
+        assertParseSuccess(parser, " g", new ListCommand(ListCommand.ListCommandType.GROUP));
+    }
+
+    @Test
+    public void parse_validArgs_returnsListMeetingCommand() {
+        assertParseSuccess(parser, " meeting", new ListCommand(ListCommand.ListCommandType.MEETING));
+        assertParseSuccess(parser, " m", new ListCommand(ListCommand.ListCommandType.MEETING));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, " a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgsWithWhitespaces_returnsListCommand() {
+        assertParseSuccess(parser, "        g", new ListCommand(ListCommand.ListCommandType.GROUP));
+        assertParseSuccess(parser, "     g   ", new ListCommand(ListCommand.ListCommandType.GROUP));
+        assertParseSuccess(parser, "g        ", new ListCommand(ListCommand.ListCommandType.GROUP));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SelectCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SelectCommandParserTest.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_GROUP;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MEETING;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.Test;
@@ -28,6 +29,12 @@ public class SelectCommandParserTest {
     public void parse_validArgs_returnsSelectGroupCommand() {
         assertParseSuccess(parser, " g/1",
             new SelectCommand(INDEX_FIRST_GROUP, SelectCommand.SelectCommandType.GROUP));
+    }
+
+    @Test
+    public void parse_validArgs_returnsSelectMeetingCommand() {
+        assertParseSuccess(parser, " m/1",
+            new SelectCommand(INDEX_FIRST_MEETING, SelectCommand.SelectCommandType.MEETING));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,6 +26,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import seedu.address.model.group.Group;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.tag.Tag;
@@ -189,6 +191,12 @@ public class AddressBookTest {
         @Override
         public ObservableList<Group> getGroupList() {
             return groups;
+        }
+
+        @Override
+        public ObservableList<Meeting> getMeetingList() {
+            List<Meeting> meetingList = groups.stream().map(Group::getMeeting).collect(Collectors.toList());
+            return FXCollections.observableArrayList(meetingList);
         }
     }
 

--- a/src/test/java/seedu/address/model/group/GroupContainsMeetingPredicateTest.java
+++ b/src/test/java/seedu/address/model/group/GroupContainsMeetingPredicateTest.java
@@ -1,0 +1,68 @@
+package seedu.address.model.group;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static seedu.address.testutil.TypicalGroups.GROUP_2101;
+import static seedu.address.testutil.TypicalGroups.NUS_BASKETBALL;
+import static seedu.address.testutil.TypicalGroups.NUS_COMPUTING;
+import static seedu.address.testutil.TypicalGroups.PROJECT_2103T;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import seedu.address.model.group.util.GroupContainsMeetingPredicate;
+
+/**
+ * Tests that a {@code Group}'s {@code Title} matches any of the keywords given.
+ * {@author jeffreyooi}
+ */
+public class GroupContainsMeetingPredicateTest {
+    @Test
+    public void equals() {
+        List<Group> firstPredicateGroupList = Collections.singletonList(GROUP_2101);
+        List<Group> secondPredicateGroupList = Arrays.asList(PROJECT_2103T, NUS_COMPUTING);
+
+        GroupContainsMeetingPredicate firstPredicate = new GroupContainsMeetingPredicate(firstPredicateGroupList);
+        GroupContainsMeetingPredicate secondPredicate = new GroupContainsMeetingPredicate(secondPredicateGroupList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        GroupContainsMeetingPredicate firstPredicateCopy = new GroupContainsMeetingPredicate(firstPredicateGroupList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(0));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different object -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_groupContainsMeeting_returnsTrue() {
+        // Matching group
+        GroupContainsMeetingPredicate predicate =
+            new GroupContainsMeetingPredicate(Collections.singletonList(NUS_COMPUTING));
+        assertTrue(predicate.test(NUS_COMPUTING.getMeeting()));
+    }
+
+    @Test
+    public void tset_groupDoesNotContainMeeting_returnsFalse() {
+        // No groups
+        GroupContainsMeetingPredicate predicate =
+            new GroupContainsMeetingPredicate(Collections.emptyList());
+        assertFalse(predicate.test(NUS_COMPUTING.getMeeting()));
+
+        // Different groups
+        predicate = new GroupContainsMeetingPredicate(Collections.singletonList(PROJECT_2103T));
+        assertFalse(predicate.test(NUS_COMPUTING.getMeeting()));
+        assertFalse(predicate.test(NUS_BASKETBALL.getMeeting()));
+    }
+}

--- a/src/test/java/seedu/address/model/group/GroupContainsPersonPredicateTest.java
+++ b/src/test/java/seedu/address/model/group/GroupContainsPersonPredicateTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertFalse;
 import static seedu.address.testutil.TypicalGroups.GROUP_2101;
 import static seedu.address.testutil.TypicalGroups.NUS_BASKETBALL;
 import static seedu.address.testutil.TypicalGroups.NUS_COMPUTING;
-import static seedu.address.testutil.TypicalGroups.PROJECT_2103T;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.CARL;

--- a/src/test/java/seedu/address/model/group/GroupContainsPersonPredicateTest.java
+++ b/src/test/java/seedu/address/model/group/GroupContainsPersonPredicateTest.java
@@ -2,9 +2,13 @@ package seedu.address.model.group;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertFalse;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUPTAG_CCA;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUPTAG_PROJECT;
+import static seedu.address.testutil.TypicalGroups.GROUP_2101;
+import static seedu.address.testutil.TypicalGroups.NUS_BASKETBALL;
+import static seedu.address.testutil.TypicalGroups.NUS_COMPUTING;
+import static seedu.address.testutil.TypicalGroups.PROJECT_2103T;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.CARL;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,8 +22,8 @@ public class GroupContainsPersonPredicateTest {
 
     @Test
     public void equals() {
-        List<String> firstPredicateKeywordList = Collections.singletonList(VALID_GROUPTAG_CCA);
-        List<String> secondPredicateKeywordList = Arrays.asList(VALID_GROUPTAG_CCA, VALID_GROUPTAG_PROJECT);
+        List<Group> firstPredicateKeywordList = Collections.singletonList(GROUP_2101);
+        List<Group> secondPredicateKeywordList = Arrays.asList(NUS_BASKETBALL, NUS_COMPUTING);
 
         GroupContainsPersonPredicate firstPredicate = new GroupContainsPersonPredicate(firstPredicateKeywordList);
         GroupContainsPersonPredicate secondPredicate = new GroupContainsPersonPredicate(secondPredicateKeywordList);
@@ -43,25 +47,24 @@ public class GroupContainsPersonPredicateTest {
 
     @Test
     public void test_groupContainsPerson_returnsTrue() {
-        // Matching keyword
+        // Person in group
         GroupContainsPersonPredicate predicate =
-            new GroupContainsPersonPredicate(Collections.singletonList(VALID_GROUPTAG_CCA));
-        assertTrue(predicate.test(BOB));
+            new GroupContainsPersonPredicate(Collections.singletonList(NUS_BASKETBALL));
+        assertTrue(predicate.test(CARL));
     }
 
     @Test
     public void test_groupDoesNotContainPerson_returnsFalse() {
-        // No keywords
+        // No group
         GroupContainsPersonPredicate predicate =
             new GroupContainsPersonPredicate(Collections.emptyList());
         assertFalse(predicate.test(BOB));
 
-        // Different case keywords (should we assume false)?
-        predicate = new GroupContainsPersonPredicate(Collections.singletonList(VALID_GROUPTAG_CCA.toLowerCase()));
+        // Person not in any group
+        predicate = new GroupContainsPersonPredicate(Arrays.asList(NUS_COMPUTING));
         assertFalse(predicate.test(BOB));
 
-        // Non-matching keyword
-        predicate = new GroupContainsPersonPredicate(Arrays.asList(VALID_GROUPTAG_PROJECT));
-        assertFalse(predicate.test(BOB));
+        // Person in another group
+        assertFalse(predicate.test(ALICE));
     }
 }

--- a/src/test/java/seedu/address/model/meeting/UniqueMeetingListTest.java
+++ b/src/test/java/seedu/address/model/meeting/UniqueMeetingListTest.java
@@ -1,0 +1,136 @@
+package seedu.address.model.meeting;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.TypicalGroups.GROUP_2101;
+import static seedu.address.testutil.TypicalGroups.PROJECT_2103T;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.model.group.Group;
+import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
+import seedu.address.testutil.GroupBuilder;
+
+/**
+ * {@author jeffreyooi}
+ */
+public class UniqueMeetingListTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final UniqueMeetingList uniqueMeetingList = new UniqueMeetingList();
+
+    @Test
+    public void contains_nullMeeting_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueMeetingList.contains(null);
+    }
+
+    @Test
+    public void contains_meetingNotInList_returnsFalse() {
+        assertFalse(uniqueMeetingList.contains(PROJECT_2103T.getMeeting()));
+    }
+
+    @Test
+    public void contains_meetingInList_returnsTrue() {
+        uniqueMeetingList.add(PROJECT_2103T.getMeeting());
+        assertTrue(uniqueMeetingList.contains(PROJECT_2103T.getMeeting()));
+    }
+
+    @Test
+    public void contains_meetingAfterEditGroup_returnsTrue() {
+        uniqueMeetingList.add(PROJECT_2103T.getMeeting());
+        Group editedGroup = new GroupBuilder(PROJECT_2103T).withTitle("CS2103").build();
+        assertTrue(uniqueMeetingList.contains(editedGroup.getMeeting()));
+    }
+
+    @Test
+    public void cancel_meetingNotInList_returnsFalse() {
+        uniqueMeetingList.add(PROJECT_2103T.getMeeting());
+        uniqueMeetingList.remove(PROJECT_2103T.getMeeting());
+        assertFalse(uniqueMeetingList.contains(PROJECT_2103T.getMeeting()));
+    }
+
+    @Test
+    public void cancel_meetingInList_returnsTrue() {
+        uniqueMeetingList.add(GROUP_2101.getMeeting());
+        uniqueMeetingList.remove(GROUP_2101.getMeeting());
+        uniqueMeetingList.add(PROJECT_2103T.getMeeting());
+        assertTrue(uniqueMeetingList.contains(PROJECT_2103T.getMeeting()));
+    }
+
+    @Test
+    public void add_nullMeeting_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueMeetingList.add(null);
+    }
+
+    @Test
+    public void setMeeting_nullTargetMeeting_returnsTrue() {
+        uniqueMeetingList.setMeeting(null, PROJECT_2103T.getMeeting());
+        assertTrue(uniqueMeetingList.contains(PROJECT_2103T.getMeeting()));
+    }
+
+    @Test
+    public void setMeeting_nullEditedMeeting_returnsFalse() {
+        uniqueMeetingList.setMeeting(PROJECT_2103T.getMeeting(), null);
+        assertFalse(uniqueMeetingList.contains(PROJECT_2103T.getMeeting()));
+    }
+
+    @Test
+    public void setMeeting_editedMeetingIsSameMeeting_success() {
+        uniqueMeetingList.add(PROJECT_2103T.getMeeting());
+        uniqueMeetingList.setMeeting(PROJECT_2103T.getMeeting(), PROJECT_2103T.getMeeting());
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        expectedUniqueMeetingList.add(PROJECT_2103T.getMeeting());
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void setMeeting_groupEditedButMeetingUnchanged_success() {
+        uniqueMeetingList.add(PROJECT_2103T.getMeeting());
+        Group editedGroup = new GroupBuilder(PROJECT_2103T).withTitle("CS2101").build();
+        uniqueMeetingList.setMeeting(PROJECT_2103T.getMeeting(), editedGroup.getMeeting());
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        expectedUniqueMeetingList.add(editedGroup.getMeeting());
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void setMeeting_editedMeetingHasDifferentIdentity_success() {
+        uniqueMeetingList.add(PROJECT_2103T.getMeeting());
+        uniqueMeetingList.setMeeting(PROJECT_2103T.getMeeting(), GROUP_2101.getMeeting());
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        expectedUniqueMeetingList.add(GROUP_2101.getMeeting());
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void remove_nullMeeting_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        uniqueMeetingList.remove(null);
+    }
+
+    @Test
+    public void remove_meetingDoesNotExist_throwsMeetingNotFoundException() {
+        thrown.expect(MeetingNotFoundException.class);
+        uniqueMeetingList.remove(PROJECT_2103T.getMeeting());
+    }
+
+    @Test
+    public void remove_existingMeeting_success() {
+        uniqueMeetingList.add(GROUP_2101.getMeeting());
+        uniqueMeetingList.remove(GROUP_2101.getMeeting());
+        UniqueMeetingList expectedUniqueMeetingList = new UniqueMeetingList();
+        assertEquals(expectedUniqueMeetingList, uniqueMeetingList);
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        thrown.expect(UnsupportedOperationException.class);
+        uniqueMeetingList.asUnmodifiableObservableList().remove(0);
+    }
+}

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.group.Group;
+import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.util.PersonPropertyComparator;
 
@@ -97,6 +98,16 @@ public class ModelStub implements Model {
 
     @Override
     public void updateSortedPersonList(PersonPropertyComparator personPropertyComparator) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Meeting> getFilteredMeetingList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredMeetingList(Predicate<Meeting> predicate) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
+++ b/src/test/java/seedu/address/ui/testutil/GuiTestAssert.java
@@ -73,7 +73,7 @@ public class GuiTestAssert {
         if (expectedGroup.getMeeting() != null) {
             assertEquals(expectedGroup.getMeeting().getTitle().fullTitle, actualCard.getGroupMeeting());
         } else {
-            assertEquals("null", actualCard.getGroupMeeting());
+            assertEquals("", actualCard.getGroupMeeting());
         }
         assertEquals(String.format("%d", expectedGroup.getMembersView().size()), actualCard.getMemberCount());
     }


### PR DESCRIPTION
This PR fixes issue #129 

Implementation:
As discussed in #129, it is implemented by creating a new list but with very limited functionalities (because it is only used for displaying on UI). The list functions are called in `addGroup`, `updateGroup` and `removeGroup` because I feel that since meeting can only be constructed by group, Model shouldn't expose functions to interact with the object. (If anyone has better implementation idea feel free to comment and we will discuss this further)

UI update:
- Group card now shows "Member count: " in front of the member count number.
- Select group now filters meeting list and person list to only show those who belong to the group

Known issues:
- If there are 2 meetings with same identities but belong to different group, select either one of the group will cause meeting pane to show both meetings (see #131)