### PR TITLE
Add labels above lists

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -24,6 +24,13 @@
     -fx-opacity: 1;
 }
 
+.label-header-medium {
+    -fx-font-size: 16pt;
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: white;
+    -fx-opacity: 1;
+}
+
 .text-field {
     -fx-font-size: 12pt;
     -fx-font-family: "Segoe UI Semibold";

--- a/src/main/resources/view/InformationDisplay.fxml
+++ b/src/main/resources/view/InformationDisplay.fxml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<GridPane id="gridPane" fx:id="gridPane" xmlns="http://javafx.com/javafx/10.0.2" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane id="gridPane" fx:id="gridPane" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="150.0" prefWidth="300.0" />
       <ColumnConstraints hgrow="SOMETIMES" minWidth="150.0" prefWidth="300.0" />
@@ -22,6 +23,10 @@
             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
          </padding>
          <children>
+            <Label styleClass="label-header-medium" text="Groups">
+               <padding>
+                  <Insets bottom="10.0" />
+               </padding></Label>
             <StackPane fx:id="groupListPanelPlaceholder" prefHeight="200.0" VBox.vgrow="ALWAYS" />
          </children>
       </VBox>
@@ -30,6 +35,10 @@
             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
          </padding>
          <children>
+            <Label styleClass="label-header-medium" text="Meetings">
+               <padding>
+                  <Insets bottom="10.0" />
+               </padding></Label>
             <StackPane fx:id="meetingListPanelPlaceholder" prefHeight="200.0" VBox.vgrow="ALWAYS" />
          </children>
       </VBox>
@@ -38,6 +47,10 @@
             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
          </padding>
          <children>
+            <Label styleClass="label-header-medium" text="Persons">
+               <padding>
+                  <Insets bottom="10.0" />
+               </padding></Label>
             <StackPane fx:id="personListPanelPlaceholder" prefHeight="200.0" VBox.vgrow="ALWAYS" />
          </children>
       </VBox>


### PR DESCRIPTION
Add labels above lists to tell user what information is displayed by each list. See image below on how it looks like now:

![image](https://user-images.githubusercontent.com/11022592/47618026-13e89b80-db09-11e8-9716-8add36f915bc.png)
