### PR TITLE
Corrected the invalid leave command usage and bug in join/leave command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/LeaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LeaveCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_GROUP_NOT_FOUND;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSON_NOT_FOUND;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import seedu.address.logic.CommandHistory;
@@ -26,10 +27,10 @@ public class LeaveCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes a person from a group in the address book. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
-            + PREFIX_NAME + "GROUP\n"
+            + PREFIX_GROUP + "GROUP\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Derek Hardy "
-            + PREFIX_NAME + "GROUP_03";
+            + PREFIX_GROUP + "GROUP_03";
 
     public static final String MESSAGE_LEAVE_SUCCESS = "Person: %1$s removed from the group: %1$s";
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -18,6 +18,7 @@ import seedu.address.model.meeting.UniqueMeetingList;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.shared.Title;
 
 /**
@@ -152,9 +153,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
-     *
      */
-    public void updatePerson(Person target, Person editedPerson) {
+    public void updatePerson(Person target, Person editedPerson) throws PersonNotFoundException {
         requireNonNull(editedPerson);
 
         // clear membership of target & set up membership for editedPerson
@@ -168,7 +168,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Replace the given group {@code target} in the list with {@code editedGroup}.
      * {@code target} must exist in the address book.
      * The group identity of {@code editedGroup} must not be the same as another existing group in the address book.
-     *
      */
     public void updateGroup(Group target, Group editedGroup) throws GroupNotFoundException {
         requireNonNull(editedGroup);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -211,12 +211,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         Person personCopy = person.copy();
         Group groupCopy = group.copy();
 
-        groupCopy.addMember(personCopy);
+        group.addMember(person);
 
-        updatePerson(person, personCopy);
-        updateGroup(group, groupCopy);
+        updatePerson(personCopy, person);
+        updateGroup(groupCopy, group);
 
-        group.addMember(person); // to satisfy the test on the input parameter
     }
 
     /**
@@ -227,10 +226,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         Person personCopy = person.copy();
         Group groupCopy = group.copy();
 
-        groupCopy.removeMember(personCopy);
+        group.removeMember(person);
 
-        updatePerson(person, personCopy);
-        updateGroup(group, groupCopy);
+        updatePerson(personCopy, person);
+        updateGroup(groupCopy, group);
     }
 
     // @@author NyxF4ll

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -85,7 +85,8 @@ public class Group {
         this.title = title;
         this.description = Optional.empty();
         this.meeting = Optional.of(meeting);
-        this.members = members;
+        this.members = new UniquePersonList();
+        this.members.setPersons(members);
     }
 
     /**
@@ -101,7 +102,8 @@ public class Group {
         this.title = title;
         this.description = Optional.of(description);
         this.meeting = Optional.empty();
-        this.members = members;
+        this.members = new UniquePersonList();
+        this.members.setPersons(members);
     }
 
     /**
@@ -119,7 +121,8 @@ public class Group {
         this.title = title;
         this.description = description;
         this.meeting = meeting;
-        this.members = members;
+        this.members = new UniquePersonList();
+        this.members.setPersons(members);
     }
 
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -26,10 +26,12 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 import seedu.address.model.group.Group;
+import seedu.address.model.group.exceptions.GroupNotFoundException;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.shared.Title;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.GroupBuilder;
@@ -91,21 +93,21 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasPerson_personInAddressBook_returnsTrue() {
+    public void addPerson_personInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);
         assertTrue(addressBook.hasPerson(ALICE));
         addressBook.removePerson(ALICE); //reset
     }
 
     @Test
-    public void hasGroup_groupInAddressBook_returnsTrue() {
+    public void addGroup_groupInAddressBook_returnsTrue() {
         AddressBook addressBook = new AddressBook();
         addressBook.addGroup(PROJECT_2103T);
         assertTrue(addressBook.hasGroup(PROJECT_2103T));
     }
 
     @Test
-    public void hasPerson_personIsRemoved_returnsFalse() {
+    public void removePerson_personIsRemoved_returnsFalse() {
         AddressBook addressBook = new AddressBook();
         addressBook.addPerson(BOB);
         addressBook.removePerson(BOB);
@@ -113,7 +115,7 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasGroup_groupIsRemoved_returnsFalse() {
+    public void removeGroup_groupIsRemoved_returnsFalse() {
         AddressBook addressBook = new AddressBook();
         addressBook.addGroup(PROJECT_2103T);
         addressBook.removeGroup(PROJECT_2103T);
@@ -121,7 +123,7 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasPerson_personIsUpdated_returnsTrue() {
+    public void updatePerson_personIsUpdated_returnsTrue() {
         AddressBook addressBook = new AddressBook();
         addressBook.addPerson(ALICE);
         addressBook.updatePerson(ALICE, BOB);
@@ -129,7 +131,7 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasPerson_personIsUpdated_returnsFalse() {
+    public void updatePerson_personIsUpdated_returnsFalse() {
         AddressBook addressBook = new AddressBook();
         addressBook.addPerson(ALICE);
         addressBook.updatePerson(ALICE, BOB);
@@ -137,7 +139,7 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasGroup_groupIsUpdated_returnsTrue() {
+    public void updateGroup_groupIsUpdated_returnsTrue() {
         AddressBook addressBook = new AddressBook();
         addressBook.addGroup(GROUP_2101);
         addressBook.updateGroup(GROUP_2101, PROJECT_2103T);
@@ -145,11 +147,32 @@ public class AddressBookTest {
     }
 
     @Test
-    public void hasGroup_groupIsUpdated_returnsFalse() {
+    public void updateGroup_groupIsUpdated_returnsFalse() {
         AddressBook addressBook = new AddressBook();
         addressBook.addGroup(GROUP_2101);
         addressBook.updateGroup(GROUP_2101, PROJECT_2103T);
         assertFalse(addressBook.hasGroup(GROUP_2101));
+    }
+
+    @Test
+    public void joinGroup_personNotExist_throwsPersonNotFoundException() {
+        thrown.expect(PersonNotFoundException.class);
+        AddressBook addressBook = new AddressBook();
+        Person outsider = new PersonBuilder().withName("outsider").build();
+        Group group = new GroupBuilder().withTitle("class").build();
+        addressBook.addGroup(group);
+        addressBook.joinGroup(outsider, group);
+    }
+
+    @Test
+    public void joinGroup_groupNotExist_throwsGroupNotFoundException() {
+        thrown.expect(GroupNotFoundException.class);
+        AddressBook addressBook = new AddressBook();
+        Person person = new PersonBuilder().withName("Derek").build();
+        Group other = new GroupBuilder().withTitle("outlier").build();
+        addressBook.addPerson(person);
+        addressBook.joinGroup(person, other);
+
     }
 
     @Test
@@ -160,7 +183,6 @@ public class AddressBookTest {
         addressBook.addPerson(person);
         addressBook.addGroup(group);
         addressBook.joinGroup(person, group);
-        //assertTrue(group.hasMember(person));
         assertTrue(person.hasGroup(group));
     }
 
@@ -173,6 +195,41 @@ public class AddressBookTest {
         addressBook.addGroup(group);
         addressBook.joinGroup(person, group);
         assertTrue(group.hasMember(person));
+    }
+
+    @Test
+    public void leaveGroup_personNotExist_throwsPersonNotFoundException() {
+        thrown.expect(PersonNotFoundException.class);
+        AddressBook addressBook = new AddressBook();
+        Person outsider = new PersonBuilder().withName("outsider").build();
+        Group group = new GroupBuilder().withTitle("class").build();
+        addressBook.addGroup(group);
+        addressBook.leaveGroup(outsider, group);
+    }
+
+
+    @Test
+    public void leaveGroup_personNotInGroup_returnsFalse() {
+        AddressBook addressBook = new AddressBook();
+        Person person = new PersonBuilder().withName("Derek").build();
+        Group group = new GroupBuilder().withTitle("class").build();
+        addressBook.addPerson(person);
+        addressBook.addGroup(group);
+        addressBook.joinGroup(person, group);
+        addressBook.leaveGroup(person, group);
+        assertFalse(person.hasGroup(group));
+    }
+
+    @Test
+    public void leaveGroup_groupHasNoPerson_returnsFalse() {
+        AddressBook addressBook = new AddressBook();
+        Person person = new PersonBuilder().withName("Derek").build();
+        Group group = new GroupBuilder().withTitle("class").build();
+        addressBook.addPerson(person);
+        addressBook.addGroup(group);
+        addressBook.joinGroup(person, group);
+        addressBook.leaveGroup(person, group);
+        assertFalse(group.hasMember(person));
     }
 
     @Test


### PR DESCRIPTION
* The command usage is corrected from PREFIX_NAME to PREFIX_GROUP
* The bug in using Join / Leave command seem to arise from incorrect Group constructor implementation, which results in undesirable object references.