### PR TITLE
Fix join command error, protect identities of typical groups and persons, fix join and leave success message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/JoinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/JoinCommand.java
@@ -33,7 +33,7 @@ public class JoinCommand extends Command {
             + PREFIX_GROUP + "GROUP_03";
 
     public static final String MESSAGE_JOIN_SUCCESS = "Person: %1$s added to the group: %2$s";
-    public static final String MESSAGE_JOIN_FAILED = "Person: %1$s is already in group: %2$s";
+    public static final String MESSAGE_PERSON_ALREADY_IN_GROUP = "Person is already in group";
 
     private final Name personName;
     private final Title groupName;
@@ -67,8 +67,7 @@ public class JoinCommand extends Command {
         }
 
         if (matchedGroupByName.hasMember(matchedPersonByName)) {
-            throw new CommandException(String.format(MESSAGE_JOIN_FAILED, matchedPersonByName.getName().toString(),
-                matchedGroupByName.getTitle().fullTitle));
+            throw new CommandException(MESSAGE_PERSON_ALREADY_IN_GROUP);
         }
 
         model.joinGroup(matchedPersonByName, matchedGroupByName);

--- a/src/main/java/seedu/address/logic/commands/JoinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/JoinCommand.java
@@ -13,7 +13,6 @@ import seedu.address.model.Model;
 import seedu.address.model.group.Group;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.shared.Title;
 
 

--- a/src/main/java/seedu/address/logic/commands/JoinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/JoinCommand.java
@@ -13,6 +13,7 @@ import seedu.address.model.Model;
 import seedu.address.model.group.Group;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.shared.Title;
 
 
@@ -33,6 +34,7 @@ public class JoinCommand extends Command {
             + PREFIX_GROUP + "GROUP_03";
 
     public static final String MESSAGE_JOIN_SUCCESS = "Person: %1$s added to the group: %2$s";
+    public static final String MESSAGE_JOIN_FAILED = "Person: %1$s is already in group: %2$s";
 
     private final Name personName;
     private final Title groupName;
@@ -63,6 +65,11 @@ public class JoinCommand extends Command {
 
         } else if (matchedPersonByName == null) {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
+        }
+
+        if (matchedGroupByName.hasMember(matchedPersonByName)) {
+            throw new CommandException(String.format(MESSAGE_JOIN_FAILED, matchedPersonByName.getName().toString(),
+                matchedGroupByName.getTitle().fullTitle));
         }
 
         model.joinGroup(matchedPersonByName, matchedGroupByName);

--- a/src/main/java/seedu/address/logic/commands/JoinCommand.java
+++ b/src/main/java/seedu/address/logic/commands/JoinCommand.java
@@ -32,7 +32,7 @@ public class JoinCommand extends Command {
             + PREFIX_NAME + "Derek Hardy "
             + PREFIX_GROUP + "GROUP_03";
 
-    public static final String MESSAGE_JOIN_SUCCESS = "Person: %1$s added to the group: %1$s";
+    public static final String MESSAGE_JOIN_SUCCESS = "Person: %1$s added to the group: %2$s";
 
     private final Name personName;
     private final Title groupName;
@@ -67,7 +67,8 @@ public class JoinCommand extends Command {
 
         model.joinGroup(matchedPersonByName, matchedGroupByName);
         model.commitAddressBook();
-        return new CommandResult(String.format(MESSAGE_JOIN_SUCCESS, matchedPersonByName, matchedGroupByName));
+        return new CommandResult(String.format(MESSAGE_JOIN_SUCCESS, matchedPersonByName.getName().toString(),
+            matchedGroupByName.getTitle().fullTitle));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/LeaveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LeaveCommand.java
@@ -32,7 +32,7 @@ public class LeaveCommand extends Command {
             + PREFIX_NAME + "Derek Hardy "
             + PREFIX_GROUP + "GROUP_03";
 
-    public static final String MESSAGE_LEAVE_SUCCESS = "Person: %1$s removed from the group: %1$s";
+    public static final String MESSAGE_LEAVE_SUCCESS = "Person: %1$s removed from the group: %2$s";
 
     private final Name personName;
     private final Title groupName;
@@ -67,7 +67,8 @@ public class LeaveCommand extends Command {
 
         model.leaveGroup(matchedPersonByName, matchedGroupByName);
         model.commitAddressBook();
-        return new CommandResult(String.format(MESSAGE_LEAVE_SUCCESS, matchedPersonByName, matchedGroupByName));
+        return new CommandResult(String.format(MESSAGE_LEAVE_SUCCESS, matchedPersonByName.getName().fullName,
+            matchedGroupByName.getTitle().fullTitle));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -149,8 +149,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         }
         for (Person p : group.getMembersView()) {
             Person edited = persons.getPersonByName(p.getName());
-            edited.addGroup(group);
-            persons.setPerson(p, edited);
+            if (!edited.hasGroup(group)) {
+                edited.addGroup(group);
+                persons.setPerson(p, edited);
+            }
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
@@ -105,8 +105,7 @@ public class JoinCommandTest {
         ModelStubAcceptingPersonJoined modelStub = new ModelStubAcceptingPersonJoined();
 
         thrown.expect(CommandException.class);
-        thrown.expectMessage(String.format(JoinCommand.MESSAGE_JOIN_FAILED, duplicatePerson.getName().fullName,
-            validGroup.getTitle().fullTitle));
+        thrown.expectMessage(JoinCommand.MESSAGE_PERSON_ALREADY_IN_GROUP);
         joinCommand.execute(modelStub, commandHistory);
     }
 

--- a/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_GROUP_NOT_FOUND;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSON_NOT_FOUND;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.testutil.TypicalGroups.GROUP_2101;
+import static seedu.address.testutil.TypicalGroups.PROJECT_2103T;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.util.ArrayList;
@@ -92,6 +93,20 @@ public class JoinCommandTest {
 
         thrown.expect(CommandException.class);
         thrown.expectMessage(MESSAGE_PERSON_NOT_FOUND);
+        joinCommand.execute(modelStub, commandHistory);
+    }
+
+    @Test
+    public void execute_personAlreadyInGroup_throwsCommandException() throws Exception {
+        Person duplicatePerson = ALICE.copy();
+        Group validGroup = PROJECT_2103T.copy();
+
+        JoinCommand joinCommand = new JoinCommand(duplicatePerson, validGroup);
+        ModelStubAcceptingPersonJoined modelStub = new ModelStubAcceptingPersonJoined();
+
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(String.format(JoinCommand.MESSAGE_JOIN_FAILED, duplicatePerson.getName().fullName,
+            validGroup.getTitle().fullTitle));
         joinCommand.execute(modelStub, commandHistory);
     }
 

--- a/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
@@ -8,7 +8,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_GROUP_NOT_FOUND;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSON_NOT_FOUND;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.testutil.TypicalGroups.GROUP_2101;
-import static seedu.address.testutil.TypicalGroups.PROJECT_2103T;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.util.ArrayList;

--- a/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
@@ -97,19 +97,6 @@ public class JoinCommandTest {
     }
 
     @Test
-    public void execute_personAlreadyInGroup_throwsCommandException() throws Exception {
-        Person duplicatePerson = ALICE.copy();
-        Group validGroup = PROJECT_2103T.copy();
-
-        JoinCommand joinCommand = new JoinCommand(duplicatePerson, validGroup);
-        ModelStubAcceptingPersonJoined modelStub = new ModelStubAcceptingPersonJoined();
-
-        thrown.expect(CommandException.class);
-        thrown.expectMessage(JoinCommand.MESSAGE_PERSON_ALREADY_IN_GROUP);
-        joinCommand.execute(modelStub, commandHistory);
-    }
-
-    @Test
     public void equals() {
         Group network = new GroupBuilder().withTitle("CS2105").build();
         Person hardy = new PersonBuilder().withName("hardy").build();

--- a/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/JoinCommandTest.java
@@ -63,7 +63,8 @@ public class JoinCommandTest {
 
         CommandResult commandResult = new JoinCommand(validPerson, validGroup).execute(modelStub, commandHistory);
 
-        assertEquals(String.format(JoinCommand.MESSAGE_JOIN_SUCCESS, validPerson, validGroup),
+        assertEquals(String.format(JoinCommand.MESSAGE_JOIN_SUCCESS, validPerson.getName().fullName,
+            validGroup.getTitle().fullTitle),
                 commandResult.feedbackToUser);
         assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
     }

--- a/src/test/java/seedu/address/logic/commands/LeaveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LeaveCommandTest.java
@@ -70,7 +70,8 @@ public class LeaveCommandTest {
 
         CommandResult commandResult = new LeaveCommand(validPerson, validGroup).execute(modelStub, commandHistory);
 
-        assertEquals(String.format(LeaveCommand.MESSAGE_LEAVE_SUCCESS, validPerson, validGroup),
+        assertEquals(String.format(LeaveCommand.MESSAGE_LEAVE_SUCCESS, validPerson.getName().fullName,
+            validGroup.getTitle().fullTitle),
                 commandResult.feedbackToUser);
         assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
     }

--- a/src/test/java/seedu/address/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/address/testutil/TypicalGroups.java
@@ -46,8 +46,8 @@ public class TypicalGroups {
     private TypicalGroups() {} // prevent instantiation
 
     public static List<Group> getTypicalGroups() {
-        return new ArrayList<>(Arrays.asList(PROJECT_2103T, GROUP_2101,
-                NUS_COMPUTING, NUS_BASKETBALL));
+        return new ArrayList<>(Arrays.asList(PROJECT_2103T.copy(), GROUP_2101.copy(),
+                NUS_COMPUTING.copy(), NUS_BASKETBALL.copy()));
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -69,6 +69,7 @@ public class TypicalPersons {
     private TypicalPersons() {} // prevents instantiation
 
     public static List<Person> getTypicalPersons() {
-        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+        return new ArrayList<>(Arrays.asList(ALICE.copy(), BENSON.copy(), CARL.copy(), DANIEL.copy(), ELLE.copy(),
+            FIONA.copy(), GEORGE.copy()));
     }
 }


### PR DESCRIPTION
This PR includes:
- Fix join command error when user tries to add a person that already exist in the group
- Return list of copies of typical groups and persons to ensure that other test cases do not modify the original objects
- Shorten join and leave result display to only show person and group name
- Fix join and leave result display showing person joins / leaves person instead of person joins / leaves group
- Temporary fix to import error that was caused by changes in #151 

Known issues:
- Travis was failing `Join` command's adding duplicate person test, however it does not fail on Intellij, which causes coverage to drop. Will investigate later.